### PR TITLE
feat: build sports analytics ai mvp

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "rules": {
+    "@next/next/no-html-link-for-pages": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+out
+.env
+.env.local
+prisma/dev.db
+prisma/dev.db-journal
+coverage
+playwright-report

--- a/README.md
+++ b/README.md
@@ -1,2 +1,121 @@
-# BET
-BET
+# 體育賽事 AI 分析 MVP (zh-Hant)
+
+此專案實作體育賽事分析網站的最小可用版本（MVP），涵蓋高勝率 / 正期望值報告、歷史賽事瀏覽、資料上傳與策略回測。所有介面與說明以繁體中文呈現，時區固定為 **Asia/Taipei**，程式碼全面採用 TypeScript。
+
+## 技術堆疊
+
+- **Next.js 14 (App Router)** + **React 18**
+- **Tailwind CSS** UI 樣式
+- **Recharts** 成效走勢圖
+- **Prisma ORM + SQLite** 持久化資料庫
+- **Zod** API 入參驗證
+- **Vitest** 單元測試 / **Playwright** 端對端測試
+
+## 快速開始
+
+```bash
+npm install
+npx prisma migrate dev
+npm run seed
+npm run dev
+```
+
+啟動後瀏覽 <http://localhost:3000>：
+
+- `/` 首頁：近期 KPI 與累積 Units 走勢圖
+- `/reports` 高勝率 / 正期望值報告（支援篩選、搜尋、CSV 匯出）
+- `/games` 歷史賽事查詢
+- `/upload` CSV 上傳與資料管理
+- `/backtest` 依參數回測策略
+
+## 資料庫 Schema（Prisma）
+
+Prisma schema 定義於 [`prisma/schema.prisma`](./prisma/schema.prisma)，核心資料表：
+
+- `Team`、`Game`、`Market`（含 `MarketType` / `MarketSelection` 枚舉）
+- `Odds`、`ModelProb`、`Pick`、`Result`、`MetricDaily`
+- `UploadLog` 紀錄上傳批次資訊
+
+種子資料位於 [`prisma/seed.ts`](./prisma/seed.ts)，自動產生近 30 天 MLB/NBA 示範紀錄，可立即在儀表板與報告頁查看高勝率 / 正期望值案例。
+
+## CSV 欄位格式
+
+範例檔案於 [`data/`](./data) 目錄：
+
+### games.csv
+
+| 欄位 | 說明 |
+| --- | --- |
+| `date` | YYYY-MM-DD （Asia/Taipei） |
+| `league` | 聯盟名稱（如 NBA、MLB） |
+| `home` / `away` | 主客隊名稱 |
+| `finalized` | true/false |
+| `result_side` | 以 `HOME:W;AWAY:L;OVER:W;UNDER:L` 格式表示賽果 |
+| `closing_total` | （選填）大小分盤口 |
+
+### odds.csv
+
+| 欄位 | 說明 |
+| --- | --- |
+| `market` | ML / SPREAD / TOTAL |
+| `selection` | HOME / AWAY / OVER / UNDER |
+| `odds_decimal` | 十進制賠率 |
+| `bookmaker` | 資料來源 |
+
+### model.csv
+
+| 欄位 | 說明 |
+| --- | --- |
+| `p_model` | 模型勝率 (0~1) |
+| `model_tag` | 模型版本標籤 |
+
+> `result_side` 解析為 `MarketSelection` 與 `ResultOutcome`，若對應市場不存在會自動建立。
+
+## 核心計算函式（`/lib/analytics.ts`）
+
+- 隱含機率 `calculateImpliedProbability`、去水錢 `removeVig`
+- 期望值 `calculateEv`、Kelly 下注比例 `calculateKellyFraction`、三檔建議 `getKellyStakeTiers`
+- Wilson 95% 信賴區間 `calculateWilsonInterval`
+- 績效彙總 `calculatePerformanceMetrics`（命中率、ROI、Units、最大回撤、每日資金曲線）
+
+## API 概覽
+
+| Method | Path | 說明 |
+| --- | --- | --- |
+| `POST` | `/api/upload` | 接收 `games.csv`/`odds.csv`/`model.csv`，驗證並寫入資料庫 |
+| `GET` | `/api/reports` | 依篩選條件回傳投注清單與 KPI |
+| `POST` | `/api/backtest` | 回測策略（最小 EV、勝率、盤口、每注單位、每日最大下注數） |
+| `GET` | `/api/games` | 查詢歷史賽程與市場結果 |
+
+所有入參採 Zod 驗證，失敗時回傳具體錯誤訊息。
+
+## 測試
+
+```bash
+# 單元測試（lib 計算函式）
+npm run test:unit
+
+# 端對端測試（Playwright）
+npm run test:e2e
+```
+
+Playwright 會啟動開發伺服器並驗證主要頁面元素、篩選器與匯出功能。
+
+## 常見問題
+
+1. **上傳失敗 / 欄位格式錯誤**：請確認欄位名稱、大小寫與 README 範例一致；`result_side` 需使用 `HOME:W;AWAY:L;OVER:W;UNDER:L` 格式。
+2. **無資料或樣本數不足**：調整日期區間、降低最低樣本數或放寬 EV / 勝率門檻。
+3. **時區問題**：系統內建使用 Asia/Taipei，請確保 CSV 的日期對應該時區。
+
+## 打包
+
+Next.js 已設定 `output: 'standalone'`，可使用官方指令建置：
+
+```bash
+npm run build
+npm run start
+```
+
+## 法規與免責聲明
+
+頁尾固定呈現：「僅供研究/娛樂用途，不提供或促成任何違法投注行為；不保證獲利。」

--- a/app/api/backtest/route.ts
+++ b/app/api/backtest/route.ts
@@ -1,0 +1,170 @@
+import { MarketType } from '@prisma/client';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+import {
+  calculateEv,
+  calculatePerformanceMetrics,
+  calculateProfit,
+  fillMissingDates,
+  toDateKey
+} from '@/lib/analytics';
+
+const bodySchema = z.object({
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  leagues: z.array(z.string()).optional(),
+  marketTypes: z.array(z.nativeEnum(MarketType)).optional(),
+  minProbability: z.number().optional().default(0.55),
+  minEv: z.number().optional().default(0),
+  stakeUnits: z.number().positive().optional().default(1),
+  maxConcurrent: z.number().int().positive().optional().default(3)
+});
+
+function parseDateInput(value?: string, hour = 0) {
+  if (!value) return undefined;
+  return new Date(`${value}T${hour.toString().padStart(2, '0')}:00:00+08:00`);
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const json = await request.json();
+    const body = bodySchema.parse(json);
+    const end = parseDateInput(body.endDate, 23) ?? new Date();
+    const start = parseDateInput(body.startDate, 0) ?? new Date(end.getTime() - 60 * 24 * 60 * 60 * 1000);
+    const marketTypes = body.marketTypes?.length
+      ? body.marketTypes
+      : [MarketType.ML, MarketType.SPREAD, MarketType.TOTAL];
+
+    const markets = await prisma.market.findMany({
+      where: {
+        type: { in: marketTypes },
+        game: {
+          date: {
+            gte: start,
+            lte: end
+          },
+          league: body.leagues?.length ? { in: body.leagues } : undefined
+        }
+      },
+      include: {
+        game: {
+          include: {
+            homeTeam: true,
+            awayTeam: true
+          }
+        },
+        odds: {
+          orderBy: { createdAt: 'desc' },
+          take: 1
+        },
+        modelProbs: {
+          orderBy: { createdAt: 'desc' },
+          take: 1
+        },
+        result: true
+      }
+    });
+
+    const grouped = new Map<string, typeof markets>();
+    for (const market of markets) {
+      const dateKey = toDateKey(market.game.date);
+      const existing = grouped.get(dateKey);
+      if (existing) {
+        existing.push(market);
+      } else {
+        grouped.set(dateKey, [market]);
+      }
+    }
+
+    const selectedPicks: {
+      id: number;
+      date: string;
+      league: string;
+      matchup: string;
+      marketType: MarketType;
+      selection: string;
+      oddsDecimal: number;
+      pModel: number;
+      ev: number;
+      result: string;
+      profit: number;
+    }[] = [];
+
+    for (const [dateKey, list] of grouped.entries()) {
+      const eligible = list
+        .map((market) => {
+          const odds = market.odds[0];
+          const model = market.modelProbs[0];
+          if (!odds || !model) return null;
+          const ev = calculateEv(model.pModel, odds.oddsDecimal);
+          if (model.pModel < body.minProbability || ev < body.minEv) return null;
+          return {
+            market,
+            ev,
+            odds,
+            model
+          };
+        })
+        .filter((item): item is { market: (typeof markets)[number]; ev: number; odds: any; model: any } => !!item)
+        .sort((a, b) => b.ev - a.ev)
+        .slice(0, body.maxConcurrent);
+
+      for (const pick of eligible) {
+        const result = pick.market.result?.outcome ?? 'PUSH';
+        const profit = calculateProfit(result, pick.odds.oddsDecimal, body.stakeUnits);
+        selectedPicks.push({
+          id: pick.market.id,
+          date: dateKey,
+          league: pick.market.game.league,
+          matchup: `${pick.market.game.awayTeam.name} @ ${pick.market.game.homeTeam.name}`,
+          marketType: pick.market.type,
+          selection: pick.market.selection,
+          oddsDecimal: Number(pick.odds.oddsDecimal.toFixed(2)),
+          pModel: Number(pick.model.pModel.toFixed(3)),
+          ev: Number(pick.ev.toFixed(3)),
+          result,
+          profit
+        });
+      }
+    }
+
+    const pickMetrics = selectedPicks
+      .sort((a, b) => a.date.localeCompare(b.date))
+      .map((pick) => ({
+        stakeUnits: body.stakeUnits,
+        oddsDecimal: pick.oddsDecimal,
+        outcome: pick.result as 'WIN' | 'LOSE' | 'PUSH',
+        date: new Date(`${pick.date}T12:00:00+08:00`)
+      }));
+    const metrics = calculatePerformanceMetrics(pickMetrics);
+    const equityCurve = fillMissingDates(metrics.equityCurve);
+
+    const dailyMap = new Map<string, number>();
+    for (const pick of selectedPicks) {
+      dailyMap.set(pick.date, (dailyMap.get(pick.date) ?? 0) + pick.profit);
+    }
+    const daily = Array.from(dailyMap.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, units]) => ({ date, units }));
+
+    let cumulative = 0;
+    const dailyWithCumulative = daily.map((item) => {
+      cumulative += item.units;
+      return { ...item, cumulative };
+    });
+
+    return NextResponse.json({
+      picks: selectedPicks,
+      summary: { ...metrics, equityCurve },
+      daily: dailyWithCumulative,
+      filters: body
+    });
+  } catch (error) {
+    console.error('回測 API 錯誤', error);
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ message: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ message: '策略回測失敗' }, { status: 500 });
+  }
+}

--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -1,0 +1,86 @@
+import { MarketType } from '@prisma/client';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+import { toDateKey } from '@/lib/analytics';
+
+const querySchema = z.object({
+  league: z.string().optional(),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  marketType: z.enum(['ML', 'SPREAD', 'TOTAL']).optional()
+});
+
+function parseDate(value?: string, hour = 0) {
+  if (!value) return undefined;
+  return new Date(`${value}T${hour.toString().padStart(2, '0')}:00:00+08:00`);
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const query = Object.fromEntries(request.nextUrl.searchParams.entries());
+    const parsed = querySchema.parse(query);
+    const end = parseDate(parsed.endDate, 23) ?? new Date();
+    const start = parseDate(parsed.startDate, 0) ?? new Date(end.getTime() - 30 * 24 * 60 * 60 * 1000);
+    const marketFilter = parsed.marketType ? MarketType[parsed.marketType] : undefined;
+
+    const games = await prisma.game.findMany({
+      where: {
+        league: parsed.league ? parsed.league : undefined,
+        date: {
+          gte: start,
+          lte: end
+        }
+      },
+      include: {
+        homeTeam: true,
+        awayTeam: true,
+        markets: {
+          where: {
+            type: marketFilter ? marketFilter : undefined
+          },
+          include: {
+            odds: {
+              orderBy: { createdAt: 'desc' },
+              take: 1
+            },
+            modelProbs: {
+              orderBy: { createdAt: 'desc' },
+              take: 1
+            },
+            result: true
+          }
+        }
+      },
+      orderBy: { date: 'desc' }
+    });
+
+    const payload = games.map((game) => ({
+      id: game.id,
+      date: toDateKey(game.date),
+      league: game.league,
+      homeTeam: game.homeTeam.name,
+      awayTeam: game.awayTeam.name,
+      finalized: game.finalized,
+      markets: game.markets.map((market) => ({
+        id: market.id,
+        type: market.type,
+        selection: market.selection,
+        line: market.line,
+        odds: market.odds[0]?.oddsDecimal ?? null,
+        bookmaker: market.odds[0]?.bookmaker ?? null,
+        pModel: market.modelProbs[0]?.pModel ?? null,
+        modelTag: market.modelProbs[0]?.modelTag ?? null,
+        result: market.result?.outcome ?? null
+      }))
+    }));
+
+    return NextResponse.json({ games: payload });
+  } catch (error) {
+    console.error('取得賽程 API 錯誤', error);
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ message: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ message: '查詢賽程失敗' }, { status: 500 });
+  }
+}

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { parseCsv } from '@/lib/csv';
+import { GameRow, importDataset, ModelRow, OddsRow } from '@/lib/upload';
+
+const gameSchema = z.object({
+  date: z.string().min(1),
+  league: z.string().min(1),
+  home: z.string().min(1),
+  away: z.string().min(1),
+  finalized: z.string().optional().default('false'),
+  result_side: z.string().optional(),
+  closing_total: z.string().optional()
+});
+
+const oddsSchema = z.object({
+  date: z.string().min(1),
+  league: z.string().min(1),
+  home: z.string().min(1),
+  away: z.string().min(1),
+  market: z.string().min(1),
+  selection: z.string().min(1),
+  odds_decimal: z.string().min(1),
+  bookmaker: z.string().min(1)
+});
+
+const modelSchema = z.object({
+  date: z.string().min(1),
+  league: z.string().min(1),
+  home: z.string().min(1),
+  away: z.string().min(1),
+  market: z.string().min(1),
+  selection: z.string().min(1),
+  p_model: z.string().min(1),
+  model_tag: z.string().min(1)
+});
+
+function toBoolean(value: string) {
+  const normalized = value.toLowerCase();
+  return ['1', 'true', 'yes', 'y'].includes(normalized);
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const gamesFile = formData.get('games');
+    const oddsFile = formData.get('odds');
+    const modelFile = formData.get('model');
+
+    if (!(gamesFile instanceof File) || !(oddsFile instanceof File) || !(modelFile instanceof File)) {
+      return NextResponse.json({ message: '缺少必要的 CSV 檔案（games/odds/model）' }, { status: 400 });
+    }
+
+    const gamesCsv = parseCsv(await gamesFile.text());
+    const oddsCsv = parseCsv(await oddsFile.text());
+    const modelCsv = parseCsv(await modelFile.text());
+
+    const games: GameRow[] = gamesCsv.rows.map((row) => {
+      const parsed = gameSchema.parse(row);
+      return {
+        date: parsed.date,
+        league: parsed.league,
+        home: parsed.home,
+        away: parsed.away,
+        finalized: toBoolean(parsed.finalized),
+        result_side: parsed.result_side,
+        closing_total: parsed.closing_total
+      };
+    });
+
+    const odds: OddsRow[] = oddsCsv.rows.map((row) => {
+      const parsed = oddsSchema.parse(row);
+      if (Number.isNaN(Number(parsed.odds_decimal))) {
+        throw new Error(`賠率欄位格式錯誤: ${parsed.odds_decimal}`);
+      }
+      return parsed;
+    });
+
+    const models: ModelRow[] = modelCsv.rows.map((row) => {
+      const parsed = modelSchema.parse(row);
+      if (Number.isNaN(Number(parsed.p_model))) {
+        throw new Error(`模型勝率格式錯誤: ${parsed.p_model}`);
+      }
+      return parsed;
+    });
+
+    const summary = await importDataset({ games, odds, models });
+
+    return NextResponse.json({
+      message: '資料匯入成功',
+      summary
+    });
+  } catch (error) {
+    console.error('資料匯入錯誤', error);
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ message: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ message: (error as Error).message ?? '資料匯入失敗' }, { status: 500 });
+  }
+}

--- a/app/backtest/page.tsx
+++ b/app/backtest/page.tsx
@@ -1,0 +1,7 @@
+import { BacktestClient } from '@/components/BacktestClient';
+import { getLeagues } from '@/lib/reporting';
+
+export default async function BacktestPage() {
+  const leagues = await getLeagues();
+  return <BacktestClient leagues={leagues} />;
+}

--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -1,0 +1,62 @@
+import { subDays } from 'date-fns';
+import { GamesClient } from '@/components/GamesClient';
+import { prisma } from '@/lib/prisma';
+import { toDateKey } from '@/lib/analytics';
+import { getLeagues } from '@/lib/reporting';
+
+export default async function GamesPage() {
+  const end = new Date();
+  const start = subDays(end, 14);
+  const [games, leagues] = await Promise.all([
+    prisma.game.findMany({
+      where: {
+        date: {
+          gte: start,
+          lte: end
+        }
+      },
+      include: {
+        homeTeam: true,
+        awayTeam: true,
+        markets: {
+          include: {
+            odds: {
+              orderBy: { createdAt: 'desc' },
+              take: 1
+            },
+            modelProbs: {
+              orderBy: { createdAt: 'desc' },
+              take: 1
+            },
+            result: true
+          }
+        }
+      },
+      orderBy: { date: 'desc' },
+      take: 40
+    }),
+    getLeagues()
+  ]);
+
+  const payload = games.map((game) => ({
+    id: game.id,
+    date: toDateKey(game.date),
+    league: game.league,
+    homeTeam: game.homeTeam.name,
+    awayTeam: game.awayTeam.name,
+    finalized: game.finalized,
+    markets: game.markets.map((market) => ({
+      id: market.id,
+      type: market.type,
+      selection: market.selection,
+      line: market.line,
+      odds: market.odds[0]?.oddsDecimal ?? null,
+      bookmaker: market.odds[0]?.bookmaker ?? null,
+      pModel: market.modelProbs[0]?.pModel ?? null,
+      modelTag: market.modelProbs[0]?.modelTag ?? null,
+      result: market.result?.outcome ?? null
+    }))
+  }));
+
+  return <GamesClient initialGames={payload} leagues={leagues} />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,23 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900 min-h-screen;
+}
+
+a {
+  @apply text-blue-600 hover:text-blue-800;
+}
+
+.card {
+  @apply rounded-2xl bg-white shadow-sm p-6;
+}
+
+.table-responsive {
+  @apply overflow-x-auto;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,61 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: '體育賽事 AI 分析儀表板',
+  description:
+    '最小可用版本的體育賽事 AI 分析網站，提供高勝率報告、回測與資金管理工具。'
+};
+
+const navItems = [
+  { href: '/', label: '首頁' },
+  { href: '/reports', label: '高勝率報告' },
+  { href: '/games', label: '賽程/歷史' },
+  { href: '/upload', label: '資料上傳' },
+  { href: '/backtest', label: '策略回測' }
+];
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="zh-Hant" data-theme="light">
+      <body className="min-h-screen">
+        <div className="min-h-screen flex flex-col">
+          <header className="bg-white shadow-sm border-b border-slate-200">
+            <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+              <div>
+                <Link href="/" className="text-xl font-semibold text-slate-800">
+                  體育賽事 AI 分析
+                </Link>
+                <p className="text-sm text-slate-500">時區：Asia/Taipei</p>
+              </div>
+              <nav className="flex gap-4 text-sm font-medium text-slate-600">
+                {navItems.map((item) => (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className="hover:text-slate-900 transition"
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+              </nav>
+            </div>
+          </header>
+          <main className="flex-1 bg-slate-50">
+            <div className="mx-auto w-full max-w-6xl px-6 py-8 space-y-6">{children}</div>
+          </main>
+          <footer className="bg-white border-t border-slate-200">
+            <div className="mx-auto max-w-6xl px-6 py-6 text-xs text-slate-500">
+              僅供研究/娛樂用途，不提供或促成任何違法投注行為；不保證獲利。
+            </div>
+          </footer>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,80 @@
+import { KpiCard } from '@/components/KpiCard';
+import { PerformanceChart } from '@/components/PerformanceChart';
+import { ReportTable } from '@/components/ReportTable';
+import { getDashboardOverview } from '@/lib/reporting';
+
+function formatPercent(value: number) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatUnits(value: number) {
+  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}u`;
+}
+
+export default async function HomePage() {
+  const dashboard = await getDashboardOverview();
+  const summary = dashboard.summary;
+  const roiPercent = formatPercent(summary.roi);
+
+  const kpis = [
+    {
+      title: '近 20 天命中率',
+      value: formatPercent(dashboard.last20.hitRate),
+      subtext: `樣本數：${dashboard.last20.sampleSize}`
+    },
+    {
+      title: '近 60 天命中率',
+      value: formatPercent(dashboard.last60.hitRate),
+      subtext: `樣本數：${dashboard.last60.sampleSize}`
+    },
+    {
+      title: '總 ROI',
+      value: roiPercent,
+      subtext: `總投注：${summary.totalStake.toFixed(2)}u`
+    },
+    {
+      title: '總盈虧 (Units)',
+      value: formatUnits(summary.units),
+      subtext: `樣本數：${summary.sampleSize}`
+    },
+    {
+      title: '最大回撤',
+      value: `-${summary.maxDrawdown.toFixed(2)}u`,
+      subtext: '依單位數計算'
+    },
+    {
+      title: 'Wilson 95% 信賴區間',
+      value: `${formatPercent(summary.hitRateInterval.low)} ~ ${formatPercent(summary.hitRateInterval.high)}`,
+      subtext: '命中率不確定性'
+    }
+  ];
+
+  const chartData = summary.equityCurve.map((point) => ({
+    ...point,
+    equity: Number(point.equity.toFixed(2)),
+    delta: Number(point.delta.toFixed(2))
+  }));
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h1 className="text-2xl font-semibold text-slate-900">體育賽事 AI 分析儀表板</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          以模型勝率與期望值選出高品質投注，提供命中率、ROI、資金曲線與 Kelly 下注建議。
+        </p>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-3 lg:grid-cols-3">{kpis.map((kpi) => <KpiCard key={kpi.title} {...kpi} />)}</section>
+
+      <PerformanceChart data={chartData} />
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-800">最新正期望值投注</h2>
+          <p className="text-xs text-slate-500">預設顯示最近 15 筆符合條件的投注樣本。</p>
+        </div>
+        <ReportTable rows={dashboard.rows.slice(0, 15)} mode="positiveEv" />
+      </section>
+    </div>
+  );
+}

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -1,0 +1,11 @@
+import { ReportsClient } from '@/components/ReportsClient';
+import { getLeagues, getReportData } from '@/lib/reporting';
+
+export default async function ReportsPage() {
+  const [initialData, leagues] = await Promise.all([
+    getReportData('positiveEv', { minSamples: 30 }),
+    getLeagues()
+  ]);
+
+  return <ReportsClient initialData={initialData} leagues={leagues} />;
+}

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -1,0 +1,16 @@
+import { UploadForm } from '@/components/UploadForm';
+
+export default function UploadPage() {
+  return (
+    <div className="space-y-6">
+      <UploadForm />
+      <section className="card space-y-2 text-sm text-slate-600">
+        <h2 className="text-base font-semibold text-slate-800">資料欄位快速提示</h2>
+        <p>games.csv：date, league, home, away, finalized, result_side, closing_total</p>
+        <p>odds.csv：date, league, home, away, market, selection, odds_decimal, bookmaker</p>
+        <p>model.csv：date, league, home, away, market, selection, p_model, model_tag</p>
+        <p>result_side 例：HOME:W;AWAY:L;OVER:W;UNDER:L</p>
+      </section>
+    </div>
+  );
+}

--- a/components/BacktestClient.tsx
+++ b/components/BacktestClient.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import { useState } from 'react';
+import { MarketType } from '@prisma/client';
+import { KpiCard } from '@/components/KpiCard';
+import { PerformanceChart } from '@/components/PerformanceChart';
+
+interface BacktestResult {
+  picks: {
+    id: number;
+    date: string;
+    league: string;
+    matchup: string;
+    marketType: MarketType;
+    selection: string;
+    oddsDecimal: number;
+    pModel: number;
+    ev: number;
+    result: string;
+    profit: number;
+  }[];
+  summary: {
+    hitRate: number;
+    hitRateInterval: { low: number; high: number };
+    roi: number;
+    units: number;
+    maxDrawdown: number;
+    sampleSize: number;
+    totalStake: number;
+    equityCurve: { date: string; delta: number; equity: number }[];
+  };
+  daily: { date: string; units: number; cumulative: number }[];
+}
+
+interface BacktestClientProps {
+  leagues: string[];
+}
+
+type MarketTypeValue = keyof typeof MarketType;
+
+const MARKET_OPTIONS: { label: string; value: MarketTypeValue }[] = [
+  { label: '獨贏 (ML)', value: 'ML' },
+  { label: '讓分 (SPREAD)', value: 'SPREAD' },
+  { label: '大小分 (TOTAL)', value: 'TOTAL' }
+];
+
+function formatPercent(value: number) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatUnits(value: number) {
+  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}u`;
+}
+
+export function BacktestClient({ leagues }: BacktestClientProps) {
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [minProbability, setMinProbability] = useState(0.6);
+  const [minEv, setMinEv] = useState(0);
+  const [stakeUnits, setStakeUnits] = useState(1);
+  const [maxConcurrent, setMaxConcurrent] = useState(3);
+  const [selectedLeagues, setSelectedLeagues] = useState<string[]>([]);
+  const [marketTypes, setMarketTypes] = useState<MarketTypeValue[]>(['ML']);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<BacktestResult | null>(null);
+
+  const handleLeagueChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const values = Array.from(event.target.selectedOptions).map((option) => option.value);
+    setSelectedLeagues(values);
+  };
+
+  const handleMarketChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const values = Array.from(event.target.selectedOptions).map((option) => option.value as MarketTypeValue);
+    setMarketTypes(values);
+  };
+
+  const runBacktest = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const payload = {
+        startDate: startDate || undefined,
+        endDate: endDate || undefined,
+        leagues: selectedLeagues.length ? selectedLeagues : undefined,
+        marketTypes: marketTypes.length ? marketTypes : undefined,
+        minProbability,
+        minEv,
+        stakeUnits,
+        maxConcurrent
+      };
+      const response = await fetch('/api/backtest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!response.ok) {
+        throw new Error(await response.text());
+      }
+      const json = (await response.json()) as BacktestResult;
+      setResult(json);
+    } catch (err) {
+      setError((err as Error).message ?? '回測失敗');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="card space-y-4">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900">策略回測</h1>
+          <p className="text-sm text-slate-500">選擇篩選條件後，系統會依日期排序逐日模擬下注。</p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            起始日期
+            <input
+              type="date"
+              value={startDate}
+              onChange={(event) => setStartDate(event.target.value)}
+              className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            結束日期
+            <input
+              type="date"
+              value={endDate}
+              onChange={(event) => setEndDate(event.target.value)}
+              className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            最低模型勝率
+            <input
+              type="number"
+              min={0}
+              max={1}
+              step={0.01}
+              value={minProbability}
+              onChange={(event) => setMinProbability(Number(event.target.value))}
+              className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            最低期望值 (EV)
+            <input
+              type="number"
+              step={0.01}
+              value={minEv}
+              onChange={(event) => setMinEv(Number(event.target.value))}
+              className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+            />
+          </label>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            每注單位 (u)
+            <input
+              type="number"
+              min={0.1}
+              step={0.1}
+              value={stakeUnits}
+              onChange={(event) => setStakeUnits(Number(event.target.value))}
+              className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            每日最大下注數
+            <input
+              type="number"
+              min={1}
+              value={maxConcurrent}
+              onChange={(event) => setMaxConcurrent(Number(event.target.value))}
+              className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            聯盟（多選）
+            <select
+              multiple
+              value={selectedLeagues}
+              onChange={handleLeagueChange}
+              className="h-32 rounded-xl border border-slate-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            >
+              {leagues.map((league) => (
+                <option key={league} value={league}>
+                  {league}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            盤口（多選）
+            <select
+              multiple
+              value={marketTypes}
+              onChange={handleMarketChange}
+              className="h-32 rounded-xl border border-slate-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            >
+              {MARKET_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          {error ? <p className="text-sm text-rose-600">{error}</p> : <span />}
+          <button
+            type="button"
+            onClick={runBacktest}
+            disabled={loading}
+            className="rounded-xl bg-blue-600 px-6 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+          >
+            {loading ? '計算中…' : '開始回測'}
+          </button>
+        </div>
+      </section>
+
+      {result ? (
+        <>
+          <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <KpiCard
+              title="命中率"
+              value={formatPercent(result.summary.hitRate)}
+              subtext={`Wilson 95%：${formatPercent(result.summary.hitRateInterval.low)} ~ ${formatPercent(result.summary.hitRateInterval.high)}`}
+            />
+            <KpiCard
+              title="ROI"
+              value={formatPercent(result.summary.roi)}
+              subtext={`總投注：${result.summary.totalStake.toFixed(2)}u`}
+            />
+            <KpiCard
+              title="累積 Units"
+              value={formatUnits(result.summary.units)}
+              subtext={`樣本數：${result.summary.sampleSize}`}
+            />
+            <KpiCard title="最大回撤" value={`-${result.summary.maxDrawdown.toFixed(2)}u`} subtext="以單位數計算" />
+          </section>
+
+          <PerformanceChart
+            data={result.summary.equityCurve.map((item) => ({
+              ...item,
+              equity: Number(item.equity.toFixed(2)),
+              delta: Number(item.delta.toFixed(2))
+            }))}
+          />
+
+          <section className="card space-y-3">
+            <h2 className="text-lg font-semibold text-slate-800">每日損益</h2>
+            <div className="table-responsive">
+              <table className="min-w-full divide-y divide-slate-200 text-sm">
+                <thead className="bg-slate-100 text-xs uppercase tracking-wide text-slate-600">
+                  <tr>
+                    <th className="px-3 py-2 text-left">日期</th>
+                    <th className="px-3 py-2 text-left">當日損益 (u)</th>
+                    <th className="px-3 py-2 text-left">累積 (u)</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {result.daily.map((day) => (
+                    <tr key={day.date}>
+                      <td className="px-3 py-2">{day.date}</td>
+                      <td className="px-3 py-2">{day.units.toFixed(2)}</td>
+                      <td className="px-3 py-2">{day.cumulative.toFixed(2)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="card space-y-3">
+            <h2 className="text-lg font-semibold text-slate-800">模擬下注紀錄</h2>
+            <div className="table-responsive">
+              <table className="min-w-full divide-y divide-slate-200 text-sm">
+                <thead className="bg-slate-100 text-xs uppercase tracking-wide text-slate-600">
+                  <tr>
+                    <th className="px-3 py-2 text-left">日期</th>
+                    <th className="px-3 py-2 text-left">聯盟</th>
+                    <th className="px-3 py-2 text-left">對賽</th>
+                    <th className="px-3 py-2 text-left">盤口</th>
+                    <th className="px-3 py-2 text-left">選項</th>
+                    <th className="px-3 py-2 text-left">賠率</th>
+                    <th className="px-3 py-2 text-left">模型勝率</th>
+                    <th className="px-3 py-2 text-left">EV</th>
+                    <th className="px-3 py-2 text-left">結果</th>
+                    <th className="px-3 py-2 text-left">單日損益</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {result.picks.map((pick) => (
+                    <tr key={`${pick.id}-${pick.date}`}>
+                      <td className="px-3 py-2">{pick.date}</td>
+                      <td className="px-3 py-2">{pick.league}</td>
+                      <td className="px-3 py-2">{pick.matchup}</td>
+                      <td className="px-3 py-2">{pick.marketType}</td>
+                      <td className="px-3 py-2">{pick.selection}</td>
+                      <td className="px-3 py-2">{pick.oddsDecimal.toFixed(2)}</td>
+                      <td className="px-3 py-2">{formatPercent(pick.pModel)}</td>
+                      <td className="px-3 py-2">{pick.ev.toFixed(3)}</td>
+                      <td className="px-3 py-2">{pick.result}</td>
+                      <td className="px-3 py-2">{pick.profit.toFixed(2)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/components/GamesClient.tsx
+++ b/components/GamesClient.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useState } from 'react';
+import { MarketType } from '@prisma/client';
+
+interface GameMarket {
+  id: number;
+  type: MarketType;
+  selection: string;
+  line: number | null;
+  odds: number | null;
+  bookmaker: string | null;
+  pModel: number | null;
+  modelTag: string | null;
+  result: string | null;
+}
+
+interface GameItem {
+  id: number;
+  date: string;
+  league: string;
+  homeTeam: string;
+  awayTeam: string;
+  finalized: boolean;
+  markets: GameMarket[];
+}
+
+interface GamesClientProps {
+  initialGames: GameItem[];
+  leagues: string[];
+}
+
+export function GamesClient({ initialGames, leagues }: GamesClientProps) {
+  const [games, setGames] = useState<GameItem[]>(initialGames);
+  const [league, setLeague] = useState('');
+  const [marketType, setMarketType] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchGames = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (league) params.set('league', league);
+      if (marketType) params.set('marketType', marketType);
+      if (startDate) params.set('startDate', startDate);
+      if (endDate) params.set('endDate', endDate);
+      const response = await fetch(`/api/games?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error(await response.text());
+      }
+      const json = (await response.json()) as { games: GameItem[] };
+      setGames(json.games);
+    } catch (err) {
+      setError((err as Error).message ?? '查詢失敗');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="card space-y-4">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900">賽程 / 歷史結果</h1>
+          <p className="text-sm text-slate-500">快速檢視近期賽事與模型評估結果。</p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            聯盟
+            <select
+              value={league}
+              onChange={(event) => setLeague(event.target.value)}
+              className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+            >
+              <option value="">全部</option>
+              {leagues.map((item) => (
+                <option key={item} value={item}>
+                  {item}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            盤口
+            <select
+              value={marketType}
+              onChange={(event) => setMarketType(event.target.value)}
+              className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+            >
+              <option value="">全部</option>
+              <option value="ML">獨贏</option>
+              <option value="SPREAD">讓分</option>
+              <option value="TOTAL">大小分</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            起始日期
+            <input
+              type="date"
+              value={startDate}
+              onChange={(event) => setStartDate(event.target.value)}
+              className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            結束日期
+            <input
+              type="date"
+              value={endDate}
+              onChange={(event) => setEndDate(event.target.value)}
+              className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+            />
+          </label>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          {error ? <p className="text-sm text-rose-600">{error}</p> : <span />}
+          <button
+            type="button"
+            onClick={fetchGames}
+            disabled={loading}
+            className="rounded-xl bg-blue-600 px-6 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+          >
+            {loading ? '載入中…' : '套用篩選'}
+          </button>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        {games.length === 0 ? (
+          <div className="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-600">
+            無符合條件的賽事。
+          </div>
+        ) : null}
+        {games.map((game) => (
+          <div key={game.id} className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+            <div className="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-xs uppercase text-slate-500">{game.league}</p>
+                <p className="text-lg font-semibold text-slate-800">
+                  {game.awayTeam} @ {game.homeTeam}
+                </p>
+                <p className="text-xs text-slate-500">日期：{game.date}</p>
+              </div>
+              <span className="text-xs font-medium text-slate-500">
+                {game.finalized ? '已結算' : '未結算'}
+              </span>
+            </div>
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              {game.markets.map((market) => (
+                <div key={market.id} className="rounded-xl border border-slate-100 bg-slate-50 p-4 text-sm text-slate-700">
+                  <p className="text-xs uppercase text-slate-500">{market.type} ｜ {market.selection}</p>
+                  {market.line !== null ? <p className="text-xs text-slate-500">盤口：{market.line}</p> : null}
+                  <p>賠率：{market.odds ?? '-'} {market.bookmaker ? `@ ${market.bookmaker}` : ''}</p>
+                  <p>模型勝率：{market.pModel !== null ? `${(market.pModel * 100).toFixed(1)}%` : '-'}</p>
+                  <p>模型版本：{market.modelTag ?? '-'}</p>
+                  <p className="font-semibold">
+                    結果：{market.result ?? '未定'}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/components/KpiCard.tsx
+++ b/components/KpiCard.tsx
@@ -1,0 +1,15 @@
+interface KpiCardProps {
+  title: string;
+  value: string;
+  subtext?: string;
+}
+
+export function KpiCard({ title, value, subtext }: KpiCardProps) {
+  return (
+    <div className="card space-y-2">
+      <p className="text-sm font-medium text-slate-500">{title}</p>
+      <p className="text-3xl font-semibold text-slate-900">{value}</p>
+      {subtext ? <p className="text-xs text-slate-500">{subtext}</p> : null}
+    </div>
+  );
+}

--- a/components/PerformanceChart.tsx
+++ b/components/PerformanceChart.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts';
+
+interface PerformanceChartProps {
+  data: { date: string; equity: number; delta: number }[];
+}
+
+export function PerformanceChart({ data }: PerformanceChartProps) {
+  return (
+    <div className="card h-80">
+      <h3 className="text-lg font-semibold text-slate-800 mb-4">累積單位數走勢</h3>
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data} margin={{ top: 10, right: 20, bottom: 0, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+          <XAxis dataKey="date" tick={{ fontSize: 12 }} minTickGap={16} />
+          <YAxis tick={{ fontSize: 12 }} width={60} />
+          <Tooltip
+            contentStyle={{ fontSize: '12px' }}
+            formatter={(value: number, name) => {
+              if (name === 'equity') return [`${value.toFixed(2)}u`, '累積單位'];
+              return [`${value.toFixed(2)}u`, '當日損益'];
+            }}
+          />
+          <Line type="monotone" dataKey="equity" stroke="#2563eb" strokeWidth={2} dot={false} />
+          <Line type="monotone" dataKey="delta" stroke="#94a3b8" strokeWidth={1} dot={false} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/components/ReportTable.tsx
+++ b/components/ReportTable.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { MarketSelection, MarketType } from '@prisma/client';
+import { ReportRow } from '@/lib/reporting';
+import clsx from 'clsx';
+
+interface ReportTableProps {
+  rows: ReportRow[];
+  mode: 'highWin' | 'positiveEv';
+}
+
+const columnHeaders = [
+  { key: 'date', label: '日期' },
+  { key: 'league', label: '聯盟' },
+  { key: 'matchup', label: '對賽' },
+  { key: 'marketType', label: '盤口' },
+  { key: 'selection', label: '投注方向' },
+  { key: 'oddsDecimal', label: '賠率' },
+  { key: 'pModel', label: '模型勝率' },
+  { key: 'pImplied', label: '隱含機率' },
+  { key: 'ev', label: 'EV' },
+  { key: 'kellyFraction', label: 'Kelly f*' },
+  { key: 'result', label: '結果' }
+] as const;
+
+type SortKey = (typeof columnHeaders)[number]['key'];
+
+type Direction = 'asc' | 'desc';
+
+function formatMarketType(type: MarketType) {
+  switch (type) {
+    case 'ML':
+      return '獨贏';
+    case 'SPREAD':
+      return '讓分';
+    case 'TOTAL':
+      return '大小分';
+    default:
+      return type;
+  }
+}
+
+function formatSelection(selection: MarketSelection) {
+  switch (selection) {
+    case 'HOME':
+      return '主隊';
+    case 'AWAY':
+      return '客隊';
+    case 'OVER':
+      return '大分';
+    case 'UNDER':
+      return '小分';
+    default:
+      return selection;
+  }
+}
+
+function toPercent(value: number) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+export function ReportTable({ rows, mode }: ReportTableProps) {
+  const [sortKey, setSortKey] = useState<SortKey>('date');
+  const [direction, setDirection] = useState<Direction>('desc');
+  const [query, setQuery] = useState('');
+
+  const filteredRows = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    const base = normalizedQuery
+      ? rows.filter((row) =>
+          [row.matchup, row.league, row.modelTag].some((field) =>
+            field.toLowerCase().includes(normalizedQuery)
+          )
+        )
+      : rows;
+
+    const sorted = [...base].sort((a, b) => {
+      const valueA = a[sortKey];
+      const valueB = b[sortKey];
+      if (typeof valueA === 'number' && typeof valueB === 'number') {
+        return direction === 'asc' ? valueA - valueB : valueB - valueA;
+      }
+      return direction === 'asc'
+        ? String(valueA).localeCompare(String(valueB))
+        : String(valueB).localeCompare(String(valueA));
+    });
+
+    return sorted;
+  }, [query, rows, sortKey, direction]);
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setDirection('desc');
+    }
+  };
+
+  const handleExport = () => {
+    const headers = [
+      'date',
+      'league',
+      'matchup',
+      'marketType',
+      'selection',
+      'oddsDecimal',
+      'pModel',
+      'pImplied',
+      'ev',
+      'kelly_25',
+      'kelly_50',
+      'kelly_100',
+      'result'
+    ];
+    const lines = filteredRows.map((row) => {
+      const tiers = ['25%', '50%', '100%'].map((key) => row.kellyTiers[key] ?? 0);
+      return [
+        row.date,
+        row.league,
+        row.matchup,
+        row.marketType,
+        row.selection,
+        row.oddsDecimal,
+        row.pModel,
+        row.pImplied,
+        row.ev,
+        ...tiers,
+        row.result
+      ].join(',');
+    });
+    const csv = [headers.join(','), ...lines].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', `report-${mode}.csv`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  return (
+    <div className="card">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-800">投注清單</h3>
+          <p className="text-xs text-slate-500">共 {filteredRows.length} 筆資料</p>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="搜尋聯盟 / 對賽 / 模型標籤"
+            className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={handleExport}
+            className="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100"
+          >
+            匯出 CSV
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <div className="table-responsive hidden md:block">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-100 text-xs uppercase tracking-wide text-slate-600">
+              <tr>
+                {columnHeaders.map((column) => (
+                  <th
+                    key={column.key}
+                    className="cursor-pointer whitespace-nowrap px-3 py-2 text-left"
+                    onClick={() => handleSort(column.key)}
+                  >
+                    <span className="flex items-center gap-1">
+                      {column.label}
+                      {sortKey === column.key ? (direction === 'asc' ? '▲' : '▼') : null}
+                    </span>
+                  </th>
+                ))}
+                <th className="px-3 py-2 text-left">建議投注</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {filteredRows.map((row) => (
+                <tr key={row.id} className="hover:bg-slate-50">
+                  <td className="whitespace-nowrap px-3 py-2 font-medium text-slate-700">{row.date}</td>
+                  <td className="px-3 py-2">{row.league}</td>
+                  <td className="px-3 py-2">{row.matchup}</td>
+                  <td className="px-3 py-2">{formatMarketType(row.marketType)}</td>
+                  <td className="px-3 py-2">{formatSelection(row.selection)}</td>
+                  <td className="px-3 py-2">{row.oddsDecimal.toFixed(2)}</td>
+                  <td className="px-3 py-2">{toPercent(row.pModel)}</td>
+                  <td className="px-3 py-2">{toPercent(row.pImplied ?? 0)}</td>
+                  <td className="px-3 py-2">{row.ev.toFixed(3)}</td>
+                  <td className="px-3 py-2">{row.kellyFraction.toFixed(3)}</td>
+                  <td
+                    className={clsx('px-3 py-2 font-semibold', {
+                      'text-emerald-600': row.result === 'WIN',
+                      'text-rose-600': row.result === 'LOSE',
+                      'text-slate-500': row.result !== 'WIN' && row.result !== 'LOSE'
+                    })}
+                  >
+                    {row.result}
+                  </td>
+                  <td className="px-3 py-2 text-xs text-slate-600">
+                    <div>0.25f*: {row.kellyTiers['25%'] ?? 0}u</div>
+                    <div>0.5f*: {row.kellyTiers['50%'] ?? 0}u</div>
+                    <div>1.0f*: {row.kellyTiers['100%'] ?? 0}u</div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="md:hidden mt-4 space-y-3">
+          {filteredRows.map((row) => (
+            <div key={row.id} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-semibold text-slate-700">{row.date}</p>
+                <span
+                  className={clsx('text-xs font-semibold', {
+                    'text-emerald-600': row.result === 'WIN',
+                    'text-rose-600': row.result === 'LOSE',
+                    'text-slate-500': row.result !== 'WIN' && row.result !== 'LOSE'
+                  })}
+                >
+                  {row.result}
+                </span>
+              </div>
+              <p className="mt-1 text-xs text-slate-500">{row.league} ｜ {formatMarketType(row.marketType)}</p>
+              <p className="mt-2 text-sm font-medium text-slate-800">{row.matchup}</p>
+              <p className="text-xs text-slate-500">{formatSelection(row.selection)}</p>
+              <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-600">
+                <div>賠率：{row.oddsDecimal.toFixed(2)}</div>
+                <div>模型勝率：{toPercent(row.pModel)}</div>
+                <div>隱含機率：{toPercent(row.pImplied ?? 0)}</div>
+                <div>EV：{row.ev.toFixed(3)}</div>
+                <div>Kelly f*：{row.kellyFraction.toFixed(3)}</div>
+                <div>建議投注：{row.kellyTiers['50%'] ?? 0}u</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ReportsClient.tsx
+++ b/components/ReportsClient.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { MarketType } from '@prisma/client';
+import { KpiCard } from '@/components/KpiCard';
+import { ReportResult } from '@/lib/reporting';
+import { ReportTable } from '@/components/ReportTable';
+
+interface ReportsClientProps {
+  initialData: ReportResult;
+  leagues: string[];
+}
+
+type MarketTypeValue = keyof typeof MarketType;
+
+type Mode = 'highWin' | 'positiveEv';
+
+const MARKET_OPTIONS: { label: string; value: MarketTypeValue }[] = [
+  { label: '獨贏 (ML)', value: 'ML' },
+  { label: '讓分 (SPREAD)', value: 'SPREAD' },
+  { label: '大小分 (TOTAL)', value: 'TOTAL' }
+];
+
+function formatPercent(value: number) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatUnits(value: number) {
+  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}u`;
+}
+
+export function ReportsClient({ initialData, leagues }: ReportsClientProps) {
+  const [mode, setMode] = useState<Mode>(initialData.mode);
+  const [data, setData] = useState<ReportResult>(initialData);
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [selectedLeagues, setSelectedLeagues] = useState<string[]>([]);
+  const [marketTypes, setMarketTypes] = useState<MarketTypeValue[]>([]);
+  const [minSamples, setMinSamples] = useState(30);
+  const [minProbability, setMinProbability] = useState(0.6);
+  const [minEv, setMinEv] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const summaryCards = useMemo(() => {
+    const summary = data.summary;
+    return [
+      {
+        title: '命中率',
+        value: formatPercent(summary.hitRate),
+        subtext: `Wilson 95%：${formatPercent(summary.hitRateInterval.low)} ~ ${formatPercent(summary.hitRateInterval.high)}`
+      },
+      {
+        title: 'ROI',
+        value: formatPercent(summary.roi),
+        subtext: `總投注：${summary.totalStake.toFixed(2)}u`
+      },
+      {
+        title: '累積 Units',
+        value: formatUnits(summary.units),
+        subtext: `樣本數：${summary.sampleSize}`
+      },
+      {
+        title: '最大回撤',
+        value: `-${summary.maxDrawdown.toFixed(2)}u`,
+        subtext: data.summary.enoughSamples ? '以完整樣本計算' : '樣本數不足'
+      }
+    ];
+  }, [data.summary]);
+
+  const handleModeChange = (nextMode: Mode) => {
+    setMode(nextMode);
+  };
+
+  const handleFetch = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      params.set('mode', mode);
+      if (startDate) params.set('startDate', startDate);
+      if (endDate) params.set('endDate', endDate);
+      if (selectedLeagues.length) params.set('leagues', selectedLeagues.join(','));
+      if (marketTypes.length) params.set('marketTypes', marketTypes.join(','));
+      if (minSamples) params.set('minSamples', String(minSamples));
+      if (mode === 'highWin') {
+        params.set('minProbability', String(minProbability));
+      }
+      if (mode === 'positiveEv') {
+        params.set('minEv', String(minEv));
+      }
+      const response = await fetch(`/api/reports?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error(await response.text());
+      }
+      const json = (await response.json()) as ReportResult;
+      setData(json);
+    } catch (err) {
+      console.error(err);
+      setError((err as Error).message ?? '取得資料失敗');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleLeagueChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const values = Array.from(event.target.selectedOptions).map((option) => option.value);
+    setSelectedLeagues(values);
+  };
+
+  const handleMarketChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const values = Array.from(event.target.selectedOptions).map((option) => option.value as MarketTypeValue);
+    setMarketTypes(values);
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="card space-y-4">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900">高勝率 / 正期望值報告</h1>
+          <p className="text-sm text-slate-500">依模型輸出與歷史結果即時篩選高品質投注樣本。</p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => handleModeChange('highWin')}
+            className={
+              mode === 'highWin'
+                ? 'rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white'
+                : 'rounded-full border border-slate-200 px-4 py-2 text-sm text-slate-600 hover:bg-slate-100'
+            }
+          >
+            高勝率（p ≥ 0.60）
+          </button>
+          <button
+            type="button"
+            onClick={() => handleModeChange('positiveEv')}
+            className={
+              mode === 'positiveEv'
+                ? 'rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white'
+                : 'rounded-full border border-slate-200 px-4 py-2 text-sm text-slate-600 hover:bg-slate-100'
+            }
+          >
+            正期望值（EV &gt; 0）
+          </button>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            起始日期
+            <input
+              type="date"
+              value={startDate}
+              onChange={(event) => setStartDate(event.target.value)}
+              className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            結束日期
+            <input
+              type="date"
+              value={endDate}
+              onChange={(event) => setEndDate(event.target.value)}
+              className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            最低樣本數
+            <input
+              type="number"
+              min={0}
+              value={minSamples}
+              onChange={(event) => setMinSamples(Number(event.target.value))}
+              className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+            />
+          </label>
+          {mode === 'highWin' ? (
+            <label className="flex flex-col gap-1 text-sm text-slate-600">
+              最低模型勝率
+              <input
+                type="number"
+                min={0}
+                max={1}
+                step={0.01}
+                value={minProbability}
+                onChange={(event) => setMinProbability(Number(event.target.value))}
+                className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+              />
+            </label>
+          ) : (
+            <label className="flex flex-col gap-1 text-sm text-slate-600">
+              最低期望值 (EV)
+              <input
+                type="number"
+                step={0.01}
+                value={minEv}
+                onChange={(event) => setMinEv(Number(event.target.value))}
+                className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+              />
+            </label>
+          )}
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            聯盟（可多選）
+            <select
+              multiple
+              value={selectedLeagues}
+              onChange={handleLeagueChange}
+              className="h-32 rounded-xl border border-slate-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            >
+              {leagues.map((league) => (
+                <option key={league} value={league}>
+                  {league}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            盤口（可多選）
+            <select
+              multiple
+              value={marketTypes}
+              onChange={handleMarketChange}
+              className="h-32 rounded-xl border border-slate-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            >
+              {MARKET_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          {error ? <p className="text-sm text-rose-600">{error}</p> : <span />}
+          <button
+            type="button"
+            onClick={handleFetch}
+            disabled={loading}
+            className="rounded-xl bg-blue-600 px-6 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+          >
+            {loading ? '載入中…' : '套用篩選條件'}
+          </button>
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {summaryCards.map((kpi) => (
+          <KpiCard key={kpi.title} {...kpi} />
+        ))}
+      </section>
+
+      {!data.summary.enoughSamples ? (
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+          樣本數不足（最低需求 {minSamples}），建議放寬日期區間或降低條件。
+        </div>
+      ) : null}
+
+      <ReportTable rows={data.rows} mode={mode} />
+    </div>
+  );
+}

--- a/components/UploadForm.tsx
+++ b/components/UploadForm.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useState } from 'react';
+
+interface UploadResponse {
+  message: string;
+  summary: {
+    gamesInserted: number;
+    oddsInserted: number;
+    modelsInserted: number;
+  };
+}
+
+export function UploadForm() {
+  const [gamesFile, setGamesFile] = useState<File | null>(null);
+  const [oddsFile, setOddsFile] = useState<File | null>(null);
+  const [modelFile, setModelFile] = useState<File | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<UploadResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!gamesFile || !oddsFile || !modelFile) {
+      setError('請選擇三個必填檔案：games.csv、odds.csv、model.csv');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const formData = new FormData();
+      formData.append('games', gamesFile);
+      formData.append('odds', oddsFile);
+      formData.append('model', modelFile);
+      const response = await fetch('/api/upload', {
+        method: 'POST',
+        body: formData
+      });
+      if (!response.ok) {
+        throw new Error(await response.text());
+      }
+      const json = (await response.json()) as UploadResponse;
+      setResult(json);
+    } catch (err) {
+      setError((err as Error).message ?? '上傳失敗');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="card space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold text-slate-900">資料上傳 / 更新</h1>
+        <p className="text-sm text-slate-500">
+          支援批次匯入模型輸出與歷史賽事資料，請依 README 指定格式上傳。
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <label className="flex flex-col gap-2 text-sm text-slate-600">
+          games.csv
+          <input
+            type="file"
+            accept=".csv"
+            onChange={(event) => setGamesFile(event.target.files?.[0] ?? null)}
+            className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+          />
+          {gamesFile ? <span className="text-xs text-slate-500">{gamesFile.name}</span> : null}
+        </label>
+        <label className="flex flex-col gap-2 text-sm text-slate-600">
+          odds.csv
+          <input
+            type="file"
+            accept=".csv"
+            onChange={(event) => setOddsFile(event.target.files?.[0] ?? null)}
+            className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+          />
+          {oddsFile ? <span className="text-xs text-slate-500">{oddsFile.name}</span> : null}
+        </label>
+        <label className="flex flex-col gap-2 text-sm text-slate-600">
+          model.csv
+          <input
+            type="file"
+            accept=".csv"
+            onChange={(event) => setModelFile(event.target.files?.[0] ?? null)}
+            className="rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-500 focus:outline-none"
+          />
+          {modelFile ? <span className="text-xs text-slate-500">{modelFile.name}</span> : null}
+        </label>
+      </div>
+
+      {error ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-3 text-sm text-rose-600">{error}</div> : null}
+      {result ? (
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+          <p className="font-semibold">{result.message}</p>
+          <p>Games：{result.summary.gamesInserted} 筆</p>
+          <p>Odds：{result.summary.oddsInserted} 筆</p>
+          <p>Model：{result.summary.modelsInserted} 筆</p>
+        </div>
+      ) : null}
+
+      <button
+        type="submit"
+        disabled={loading}
+        className="rounded-xl bg-blue-600 px-6 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+      >
+        {loading ? '上傳中…' : '送出'}
+      </button>
+    </form>
+  );
+}

--- a/data/games.csv
+++ b/data/games.csv
@@ -1,0 +1,5 @@
+date,league,home,away,finalized,result_side,closing_total
+2024-04-01,NBA,台北戰神,高雄火焰,true,HOME:W;AWAY:L;OVER:W;UNDER:L,220.5
+2024-04-01,MLB,台北猛虎,台中飛魚,true,HOME:L;AWAY:W;OVER:L;UNDER:W,8.5
+2024-04-02,NBA,新竹巨浪,台中雷霆,true,HOME:L;AWAY:W;OVER:L;UNDER:W,218.0
+2024-04-02,MLB,高雄犀牛,花蓮鯨,true,HOME:W;AWAY:L;OVER:W;UNDER:L,9.0

--- a/data/model.csv
+++ b/data/model.csv
@@ -1,0 +1,9 @@
+date,league,home,away,market,selection,p_model,model_tag
+2024-04-01,NBA,台北戰神,高雄火焰,ML,HOME,0.66,baseline_v1
+2024-04-01,NBA,台北戰神,高雄火焰,ML,AWAY,0.32,baseline_v1
+2024-04-01,NBA,台北戰神,高雄火焰,TOTAL,OVER,0.64,baseline_v1
+2024-04-01,NBA,台北戰神,高雄火焰,TOTAL,UNDER,0.31,baseline_v1
+2024-04-01,MLB,台北猛虎,台中飛魚,ML,HOME,0.59,baseline_v1
+2024-04-01,MLB,台北猛虎,台中飛魚,ML,AWAY,0.38,baseline_v1
+2024-04-02,NBA,新竹巨浪,台中雷霆,ML,HOME,0.62,baseline_v1
+2024-04-02,NBA,新竹巨浪,台中雷霆,ML,AWAY,0.35,baseline_v1

--- a/data/odds.csv
+++ b/data/odds.csv
@@ -1,0 +1,9 @@
+date,league,home,away,market,selection,odds_decimal,bookmaker
+2024-04-01,NBA,台北戰神,高雄火焰,ML,HOME,1.72,DemoBook
+2024-04-01,NBA,台北戰神,高雄火焰,ML,AWAY,2.15,DemoBook
+2024-04-01,NBA,台北戰神,高雄火焰,TOTAL,OVER,1.91,DemoBook
+2024-04-01,NBA,台北戰神,高雄火焰,TOTAL,UNDER,1.95,DemoBook
+2024-04-01,MLB,台北猛虎,台中飛魚,ML,HOME,1.68,DemoBook
+2024-04-01,MLB,台北猛虎,台中飛魚,ML,AWAY,2.25,DemoBook
+2024-04-02,NBA,新竹巨浪,台中雷霆,ML,HOME,1.82,DemoBook
+2024-04-02,NBA,新竹巨浪,台中雷霆,ML,AWAY,2.05,DemoBook

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,194 @@
+import { addDays } from 'date-fns';
+
+type Outcome = 'WIN' | 'LOSE' | 'PUSH';
+
+type PickLike = {
+  stakeUnits: number;
+  oddsDecimal: number;
+  outcome: Outcome;
+  date: Date;
+};
+
+export function calculateImpliedProbability(oddsDecimal: number): number {
+  if (oddsDecimal <= 1) {
+    throw new Error('賠率必須大於 1');
+  }
+  return 1 / oddsDecimal;
+}
+
+export function removeVig(odds: number[]): number[] {
+  if (odds.length === 0) return [];
+  const raw = odds.map((odd) => calculateImpliedProbability(odd));
+  const total = raw.reduce((acc, cur) => acc + cur, 0);
+  if (total === 0) {
+    return raw.map(() => 0);
+  }
+  return raw.map((val) => val / total);
+}
+
+export function calculateEv(pModel: number, oddsDecimal: number): number {
+  const edge = oddsDecimal - 1;
+  return pModel * edge - (1 - pModel);
+}
+
+export function calculateKellyFraction(pModel: number, oddsDecimal: number): number {
+  const b = oddsDecimal - 1;
+  if (b <= 0) return 0;
+  const numerator = b * pModel - (1 - pModel);
+  const fraction = numerator / b;
+  return fraction > 0 ? fraction : 0;
+}
+
+export function getKellyStakeTiers(
+  bankrollUnits: number,
+  kellyFraction: number,
+  factors: number[] = [0.25, 0.5, 1]
+): Record<string, number> {
+  const rounded = (value: number) => Math.round(value * 100) / 100;
+  const entries = factors.map((factor) => {
+    const key = `${Math.round(factor * 100)}%`;
+    const units = bankrollUnits * kellyFraction * factor;
+    return [key, rounded(units)];
+  });
+  return Object.fromEntries(entries);
+}
+
+export function calculateWilsonInterval(
+  successes: number,
+  total: number,
+  confidence = 0.95
+): { low: number; high: number } {
+  if (total === 0) {
+    return { low: 0, high: 0 };
+  }
+  const z = confidence === 0.95 ? 1.96 : Math.sqrt(2) * erfInv(confidence);
+  const pHat = successes / total;
+  const denominator = 1 + (z * z) / total;
+  const centre = pHat + (z * z) / (2 * total);
+  const margin =
+    (z * Math.sqrt((pHat * (1 - pHat)) / total + (z * z) / (4 * total * total))) /
+    denominator;
+  return {
+    low: Math.max(0, (centre - margin) / denominator),
+    high: Math.min(1, (centre + margin) / denominator)
+  };
+}
+
+function erfInv(x: number): number {
+  const a = 0.147; // approximation constant
+  const ln = Math.log(1 - x * x);
+  const first = (2 / (Math.PI * a)) + ln / 2;
+  const second = ln / a;
+  return Math.sign(x) * Math.sqrt(Math.sqrt(first * first - second) - first);
+}
+
+export function calculateProfit(outcome: Outcome, oddsDecimal: number, stakeUnits: number): number {
+  switch (outcome) {
+    case 'WIN':
+      return (oddsDecimal - 1) * stakeUnits;
+    case 'LOSE':
+      return -stakeUnits;
+    default:
+      return 0;
+  }
+}
+
+export function toDateKey(date: Date, timeZone = 'Asia/Taipei'): string {
+  const locale = date.toLocaleString('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  });
+  const [month, day, year] = locale.split('/');
+  return `${year}-${month}-${day}`;
+}
+
+export function calculatePerformanceMetrics(picks: PickLike[]) {
+  if (picks.length === 0) {
+    return {
+      hitRate: 0,
+      hitRateInterval: { low: 0, high: 0 },
+      roi: 0,
+      units: 0,
+      maxDrawdown: 0,
+      sampleSize: 0,
+      totalStake: 0,
+      equityCurve: [] as { date: string; delta: number; equity: number }[]
+    };
+  }
+
+  const sorted = [...picks].sort((a, b) => a.date.getTime() - b.date.getTime());
+  let equity = 0;
+  let peak = 0;
+  let maxDrawdown = 0;
+  let wins = 0;
+  let losses = 0;
+  let totalStake = 0;
+  const dailyMap = new Map<string, { delta: number; equity: number }>();
+
+  for (const pick of sorted) {
+    const profit = calculateProfit(pick.outcome, pick.oddsDecimal, pick.stakeUnits);
+    if (pick.outcome !== 'PUSH') {
+      totalStake += pick.stakeUnits;
+    }
+    if (pick.outcome === 'WIN') wins += 1;
+    if (pick.outcome === 'LOSE') losses += 1;
+    equity += profit;
+    peak = Math.max(peak, equity);
+    maxDrawdown = Math.max(maxDrawdown, peak - equity);
+
+    const key = toDateKey(pick.date);
+    const existing = dailyMap.get(key) ?? { delta: 0, equity: 0 };
+    existing.delta += profit;
+    existing.equity = equity;
+    dailyMap.set(key, existing);
+  }
+
+  const sampleSize = wins + losses;
+  const hitRate = sampleSize ? wins / sampleSize : 0;
+  const hitRateInterval = calculateWilsonInterval(wins, sampleSize);
+  const units = equity;
+  const roi = totalStake > 0 ? units / totalStake : 0;
+
+  const equityCurve = Array.from(dailyMap.entries())
+    .sort(([a], [b]) => (a > b ? 1 : -1))
+    .map(([date, value]) => ({ date, delta: value.delta, equity: value.equity }));
+
+  return {
+    hitRate,
+    hitRateInterval,
+    roi,
+    units,
+    maxDrawdown,
+    sampleSize,
+    totalStake,
+    equityCurve
+  };
+}
+
+export function fillMissingDates(
+  curve: { date: string; delta: number; equity: number }[],
+  timeZone = 'Asia/Taipei'
+) {
+  if (curve.length === 0) return curve;
+  const filled: { date: string; delta: number; equity: number }[] = [];
+  let prevDate = new Date(`${curve[0].date}T00:00:00`);
+  let equity = curve[0].equity - curve[0].delta;
+
+  for (const point of curve) {
+    const currentDate = new Date(`${point.date}T00:00:00`);
+    while (prevDate < currentDate) {
+      const key = toDateKey(prevDate, timeZone);
+      filled.push({ date: key, delta: 0, equity });
+      prevDate = addDays(prevDate, 1);
+    }
+    filled.push(point);
+    equity = point.equity;
+    prevDate = addDays(currentDate, 1);
+  }
+
+  return filled;
+}
+
+export type { PickLike };

--- a/lib/csv.ts
+++ b/lib/csv.ts
@@ -1,0 +1,17 @@
+export function parseCsv(text: string) {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length === 0) return { header: [], rows: [] };
+  const header = lines[0].split(',').map((item) => item.trim());
+  const rows = lines.slice(1).map((line) => {
+    const values = line.split(',');
+    const record: Record<string, string> = {};
+    header.forEach((key, index) => {
+      record[key] = values[index]?.trim() ?? '';
+    });
+    return record;
+  });
+  return { header, rows };
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: ['info', 'warn', 'error']
+  });
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}

--- a/lib/reporting.ts
+++ b/lib/reporting.ts
@@ -1,0 +1,262 @@
+import { MarketSelection, MarketType } from '@prisma/client';
+import { subDays } from 'date-fns';
+import { prisma } from './prisma';
+import {
+  calculateEv,
+  calculateImpliedProbability,
+  calculateKellyFraction,
+  calculatePerformanceMetrics,
+  calculateProfit,
+  fillMissingDates,
+  getKellyStakeTiers,
+  removeVig,
+  toDateKey
+} from './analytics';
+
+export type ReportMode = 'highWin' | 'positiveEv';
+
+export interface ReportFilters {
+  startDate?: string;
+  endDate?: string;
+  leagues?: string[];
+  marketTypes?: MarketType[];
+  minSamples?: number;
+  minProbability?: number;
+  minEv?: number;
+}
+
+export interface ReportRow {
+  id: number;
+  date: string;
+  league: string;
+  matchup: string;
+  marketType: MarketType;
+  selection: MarketSelection;
+  oddsDecimal: number;
+  bookmaker: string;
+  pModel: number;
+  modelTag: string;
+  pImplied: number | null;
+  ev: number;
+  kellyFraction: number;
+  kellyTiers: Record<string, number>;
+  result: 'WIN' | 'LOSE' | 'PUSH' | 'PENDING';
+  unitsDelta: number;
+}
+
+export interface ReportSummary {
+  hitRate: number;
+  hitRateInterval: { low: number; high: number };
+  roi: number;
+  units: number;
+  maxDrawdown: number;
+  sampleSize: number;
+  totalStake: number;
+  equityCurve: { date: string; delta: number; equity: number }[];
+  enoughSamples: boolean;
+  totalPicks: number;
+}
+
+export interface ReportResult {
+  rows: ReportRow[];
+  summary: ReportSummary;
+  filters: ReportFilters;
+  mode: ReportMode;
+}
+
+const DEFAULT_RANGE_DAYS = 30;
+const BANKROLL_UNITS = 1;
+
+function parseDateInput(date: string, hour = 0) {
+  return new Date(`${date}T${hour.toString().padStart(2, '0')}:00:00+08:00`);
+}
+
+function resolveDateRange(filters: ReportFilters) {
+  const end = filters.endDate ? parseDateInput(filters.endDate, 23) : new Date();
+  const start = filters.startDate
+    ? parseDateInput(filters.startDate, 0)
+    : subDays(end, DEFAULT_RANGE_DAYS);
+  return { start, end };
+}
+
+function formatMatchup(home: string, away: string) {
+  return `${away} @ ${home}`;
+}
+
+export async function getLeagues(): Promise<string[]> {
+  const leagues = await prisma.game.findMany({
+    select: { league: true },
+    distinct: ['league'],
+    orderBy: { league: 'asc' }
+  });
+  return leagues.map((item) => item.league);
+}
+
+export async function getReportData(
+  mode: ReportMode,
+  filters: ReportFilters = {}
+): Promise<ReportResult> {
+  const { start, end } = resolveDateRange(filters);
+  const marketTypes = filters.marketTypes?.length
+    ? filters.marketTypes
+    : [MarketType.ML, MarketType.SPREAD, MarketType.TOTAL];
+
+  const markets = await prisma.market.findMany({
+    where: {
+      type: { in: marketTypes },
+      game: {
+        date: {
+          gte: start,
+          lte: end
+        },
+        league: filters.leagues?.length ? { in: filters.leagues } : undefined
+      }
+    },
+    include: {
+      game: {
+        include: {
+          homeTeam: true,
+          awayTeam: true
+        }
+      },
+      odds: {
+        orderBy: { createdAt: 'desc' },
+        take: 1
+      },
+      modelProbs: {
+        orderBy: { createdAt: 'desc' },
+        take: 1
+      },
+      result: true
+    }
+  });
+
+  const groupedOdds = new Map<string, number[]>();
+  const groupedIds: Record<string, number[]> = {};
+
+  for (const market of markets) {
+    const key = `${market.gameId}-${market.type}`;
+    const oddsValue = market.odds[0]?.oddsDecimal ?? null;
+    if (!groupedIds[key]) {
+      groupedIds[key] = [];
+    }
+    groupedIds[key].push(market.id);
+    if (!groupedOdds.has(key)) {
+      groupedOdds.set(key, []);
+    }
+    if (oddsValue) {
+      groupedOdds.get(key)!.push(oddsValue);
+    }
+  }
+
+  const impliedMap = new Map<number, number>();
+  for (const [groupKey, oddsList] of groupedOdds.entries()) {
+    if (oddsList.length === 0) continue;
+    const normalized = removeVig(oddsList);
+    const ids = groupedIds[groupKey];
+    normalized.forEach((prob, index) => {
+      const marketId = ids[index];
+      impliedMap.set(marketId, prob);
+    });
+  }
+
+  const rows: ReportRow[] = [];
+
+  for (const market of markets) {
+    const latestOdds = market.odds[0];
+    const latestModel = market.modelProbs[0];
+    if (!latestOdds || !latestModel) continue;
+
+    const pModel = latestModel.pModel;
+    const ev = calculateEv(pModel, latestOdds.oddsDecimal);
+    const passesRule =
+      mode === 'highWin'
+        ? pModel >= (filters.minProbability ?? 0.6)
+        : ev >= (filters.minEv ?? 0);
+    if (!passesRule) continue;
+
+    const dateKey = toDateKey(market.game.date);
+    const implied = impliedMap.get(market.id) ?? calculateImpliedProbability(latestOdds.oddsDecimal);
+    const kellyFraction = calculateKellyFraction(pModel, latestOdds.oddsDecimal);
+    const kellyTiers = getKellyStakeTiers(BANKROLL_UNITS, kellyFraction);
+
+    const outcome = market.result?.outcome ?? null;
+    const result: ReportRow['result'] = outcome ? outcome : 'PENDING';
+    const unitsDelta = outcome
+      ? calculateProfit(outcome, latestOdds.oddsDecimal, BANKROLL_UNITS)
+      : 0;
+
+    rows.push({
+      id: market.id,
+      date: dateKey,
+      league: market.game.league,
+      matchup: formatMatchup(market.game.homeTeam.name, market.game.awayTeam.name),
+      marketType: market.type,
+      selection: market.selection,
+      oddsDecimal: Number(latestOdds.oddsDecimal.toFixed(2)),
+      bookmaker: latestOdds.bookmaker,
+      pModel: Number(pModel.toFixed(3)),
+      modelTag: latestModel.modelTag,
+      pImplied: Number(implied.toFixed(3)),
+      ev: Number(ev.toFixed(3)),
+      kellyFraction: Number(kellyFraction.toFixed(3)),
+      kellyTiers,
+      result,
+      unitsDelta
+    });
+  }
+
+  rows.sort((a, b) => (a.date === b.date ? b.id - a.id : a.date > b.date ? -1 : 1));
+
+  const picksForMetrics = rows.map((row) => ({
+    stakeUnits: BANKROLL_UNITS,
+    oddsDecimal: row.oddsDecimal,
+    outcome: (row.result === 'PENDING' ? 'PUSH' : row.result) as 'WIN' | 'LOSE' | 'PUSH',
+    date: new Date(`${row.date}T12:00:00+08:00`)
+  }));
+
+  const metrics = calculatePerformanceMetrics(picksForMetrics);
+  const enoughSamples = rows.length >= (filters.minSamples ?? 0);
+
+  const summary: ReportSummary = {
+    ...metrics,
+    equityCurve: fillMissingDates(metrics.equityCurve),
+    enoughSamples,
+    totalPicks: rows.length
+  };
+
+  return {
+    rows,
+    summary,
+    filters,
+    mode
+  };
+}
+
+export async function getDashboardOverview() {
+  const filters: ReportFilters = {};
+  const report = await getReportData('positiveEv', filters);
+  const now = new Date();
+  const start20 = subDays(now, 20);
+  const start60 = subDays(now, 60);
+
+  const picks = report.rows.map((row) => ({
+    stakeUnits: BANKROLL_UNITS,
+    oddsDecimal: row.oddsDecimal,
+    outcome: row.result as 'WIN' | 'LOSE' | 'PUSH',
+    date: new Date(`${row.date}T12:00:00+08:00`)
+  }));
+
+  const picks20 = picks.filter((pick) => pick.date >= start20);
+  const picks60 = picks.filter((pick) => pick.date >= start60);
+
+  const metrics20 = calculatePerformanceMetrics(picks20);
+  const metrics60 = calculatePerformanceMetrics(picks60);
+
+  return {
+    summary: report.summary,
+    last20: metrics20,
+    last60: metrics60,
+    rows: report.rows
+  };
+}

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -1,0 +1,303 @@
+import { MarketSelection, MarketType, ResultOutcome } from '@prisma/client';
+import { prisma } from './prisma';
+
+export interface GameRow {
+  date: string;
+  league: string;
+  home: string;
+  away: string;
+  finalized: boolean;
+  result_side?: string;
+  closing_total?: string;
+}
+
+export interface OddsRow {
+  date: string;
+  league: string;
+  home: string;
+  away: string;
+  market: string;
+  selection: string;
+  odds_decimal: string;
+  bookmaker: string;
+}
+
+export interface ModelRow {
+  date: string;
+  league: string;
+  home: string;
+  away: string;
+  market: string;
+  selection: string;
+  p_model: string;
+  model_tag: string;
+}
+
+function parseDate(value: string) {
+  return new Date(`${value}T12:00:00+08:00`);
+}
+
+function marketTypeFromString(value: string): MarketType {
+  const normalized = value.toUpperCase();
+  if (normalized === 'ML' || normalized === 'MONEYLINE') return MarketType.ML;
+  if (normalized === 'SPREAD') return MarketType.SPREAD;
+  if (normalized === 'TOTAL' || normalized === 'OU' || normalized === 'O/U') return MarketType.TOTAL;
+  throw new Error(`未知的盤口類型: ${value}`);
+}
+
+function selectionFromString(value: string): MarketSelection {
+  const normalized = value.toUpperCase();
+  switch (normalized) {
+    case 'HOME':
+    case 'H':
+      return MarketSelection.HOME;
+    case 'AWAY':
+    case 'A':
+      return MarketSelection.AWAY;
+    case 'OVER':
+    case 'O':
+      return MarketSelection.OVER;
+    case 'UNDER':
+    case 'U':
+      return MarketSelection.UNDER;
+    default:
+      throw new Error(`未知的投注選項: ${value}`);
+  }
+}
+
+function outcomeFromString(value: string): ResultOutcome {
+  const normalized = value.toUpperCase();
+  if (normalized === 'W' || normalized === 'WIN') return ResultOutcome.WIN;
+  if (normalized === 'L' || normalized === 'LOSE') return ResultOutcome.LOSE;
+  if (normalized === 'P' || normalized === 'PUSH') return ResultOutcome.PUSH;
+  throw new Error(`未知的賽果標記: ${value}`);
+}
+
+function parseResultSide(value?: string) {
+  const result: Partial<Record<MarketSelection, ResultOutcome>> = {};
+  if (!value) return result;
+  const tokens = value.split(/[;|]/).map((item) => item.trim()).filter(Boolean);
+  for (const token of tokens) {
+    const [rawSelection, rawOutcome] = token.split(':').map((item) => item.trim());
+    if (!rawSelection || !rawOutcome) continue;
+    const selection = selectionFromString(rawSelection);
+    result[selection] = outcomeFromString(rawOutcome);
+  }
+  return result;
+}
+
+const teamCache = new Map<string, number>();
+const gameCache = new Map<string, number>();
+const marketCache = new Map<string, number>();
+
+async function getTeamId(league: string, name: string) {
+  const key = `${league}|${name}`;
+  if (teamCache.has(key)) return teamCache.get(key)!;
+  const existing = await prisma.team.findFirst({
+    where: { league, name }
+  });
+  if (existing) {
+    teamCache.set(key, existing.id);
+    return existing.id;
+  }
+  const created = await prisma.team.create({
+    data: { league, name }
+  });
+  teamCache.set(key, created.id);
+  return created.id;
+}
+
+function gameKey(league: string, date: string, home: string, away: string) {
+  return `${league}|${date}|${home}|${away}`;
+}
+
+async function getGameId(row: GameRow) {
+  const key = gameKey(row.league, row.date, row.home, row.away);
+  if (gameCache.has(key)) return gameCache.get(key)!;
+  const date = parseDate(row.date);
+  const homeTeamId = await getTeamId(row.league, row.home);
+  const awayTeamId = await getTeamId(row.league, row.away);
+  const existing = await prisma.game.findFirst({
+    where: {
+      league: row.league,
+      date,
+      homeTeamId,
+      awayTeamId
+    }
+  });
+  if (existing) {
+    gameCache.set(key, existing.id);
+    return existing.id;
+  }
+  const created = await prisma.game.create({
+    data: {
+      league: row.league,
+      date,
+      finalized: row.finalized,
+      homeTeamId,
+      awayTeamId
+    }
+  });
+  gameCache.set(key, created.id);
+  return created.id;
+}
+
+async function ensureMarket(
+  gameId: number,
+  type: MarketType,
+  selection: MarketSelection,
+  line?: number | null
+) {
+  const key = `${gameId}|${type}|${selection}`;
+  if (marketCache.has(key)) return marketCache.get(key)!;
+  const existing = await prisma.market.findFirst({
+    where: {
+      gameId,
+      type,
+      selection
+    }
+  });
+  if (existing) {
+    marketCache.set(key, existing.id);
+    if (line !== undefined && line !== null) {
+      await prisma.market.update({
+        where: { id: existing.id },
+        data: { line }
+      });
+    }
+    return existing.id;
+  }
+  const created = await prisma.market.create({
+    data: {
+      gameId,
+      type,
+      selection,
+      line
+    }
+  });
+  marketCache.set(key, created.id);
+  return created.id;
+}
+
+export async function importDataset({
+  games,
+  odds,
+  models
+}: {
+  games: GameRow[];
+  odds: OddsRow[];
+  models: ModelRow[];
+}) {
+  teamCache.clear();
+  gameCache.clear();
+  marketCache.clear();
+  let gamesInserted = 0;
+  let oddsInserted = 0;
+  let modelsInserted = 0;
+  const closingTotals = new Map<string, number>();
+
+  for (const row of games) {
+    const gameId = await getGameId(row);
+    gamesInserted += 1;
+    await prisma.game.update({
+      where: { id: gameId },
+      data: { finalized: row.finalized }
+    });
+    const closingTotal = row.closing_total ? Number(row.closing_total) : undefined;
+    if (closingTotal) {
+      closingTotals.set(`${gameId}|TOTAL`, closingTotal);
+    }
+    const resultInfo = parseResultSide(row.result_side);
+    for (const [selection, outcome] of Object.entries(resultInfo)) {
+      const marketType =
+        selection === MarketSelection.OVER || selection === MarketSelection.UNDER
+          ? MarketType.TOTAL
+          : MarketType.ML;
+      const marketId = await ensureMarket(
+        gameId,
+        marketType,
+        selection as MarketSelection,
+        marketType === MarketType.TOTAL ? closingTotal ?? null : undefined
+      );
+      await prisma.result.upsert({
+        where: { marketId },
+        create: {
+          marketId,
+          outcome: outcome!,
+          settledAt: new Date()
+        },
+        update: {
+          outcome: outcome!,
+          settledAt: new Date()
+        }
+      });
+    }
+  }
+
+  for (const row of odds) {
+    const base: GameRow = {
+      date: row.date,
+      league: row.league,
+      home: row.home,
+      away: row.away,
+      finalized: false
+    };
+    const gameId = await getGameId(base);
+    const type = marketTypeFromString(row.market);
+    const selection = selectionFromString(row.selection);
+    const lineKey = `${gameId}|${type}`;
+    const line = closingTotals.get(lineKey) ?? null;
+    const marketId = await ensureMarket(gameId, type, selection, line);
+    await prisma.odds.create({
+      data: {
+        marketId,
+        bookmaker: row.bookmaker,
+        oddsDecimal: Number(row.odds_decimal),
+        createdAt: parseDate(row.date)
+      }
+    });
+    oddsInserted += 1;
+  }
+
+  for (const row of models) {
+    const base: GameRow = {
+      date: row.date,
+      league: row.league,
+      home: row.home,
+      away: row.away,
+      finalized: false
+    };
+    const gameId = await getGameId(base);
+    const type = marketTypeFromString(row.market);
+    const selection = selectionFromString(row.selection);
+    const lineKey = `${gameId}|${type}`;
+    const line = closingTotals.get(lineKey) ?? null;
+    const marketId = await ensureMarket(gameId, type, selection, line);
+    await prisma.modelProb.create({
+      data: {
+        marketId,
+        pModel: Number(row.p_model),
+        modelTag: row.model_tag,
+        createdAt: parseDate(row.date)
+      }
+    });
+    modelsInserted += 1;
+  }
+
+  await prisma.uploadLog.create({
+    data: {
+      filename: `manual-upload-${new Date().toISOString()}`,
+      meta: {
+        gamesInserted,
+        oddsInserted,
+        modelsInserted
+      }
+    }
+  });
+
+  return {
+    gamesInserted,
+    oddsInserted,
+    modelsInserted
+  };
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: true
+  },
+  reactStrictMode: true,
+  output: 'standalone',
+  env: {
+    DEFAULT_TIMEZONE: 'Asia/Taipei'
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "sports-ai-analytics",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "seed": "ts-node prisma/seed.ts",
+    "import:sample": "ts-node scripts/importCsv.ts",
+    "backtest:cli": "ts-node scripts/backtest.ts",
+    "test:unit": "vitest run",
+    "test:e2e": "playwright test",
+    "test": "npm run test:unit && npm run test:e2e"
+  },
+  "dependencies": {
+    "@prisma/client": "5.15.0",
+    "@tanstack/react-table": "8.13.2",
+    "clsx": "2.1.0",
+    "date-fns": "3.6.0",
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "recharts": "2.7.2",
+    "zod": "3.23.8"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.44.1",
+    "@types/node": "20.12.7",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "10.4.19",
+    "esbuild": "0.20.2",
+    "postcss": "8.4.38",
+    "prisma": "5.15.0",
+    "tailwindcss": "3.4.3",
+    "ts-node": "10.9.2",
+    "typescript": "5.4.5",
+    "vitest": "1.5.0",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  timeout: 60_000,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry'
+  },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ]
+});

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,116 @@
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+enum MarketType {
+  ML
+  SPREAD
+  TOTAL
+}
+
+enum MarketSelection {
+  HOME
+  AWAY
+  OVER
+  UNDER
+}
+
+enum PickSelection {
+  HOME
+  AWAY
+  OVER
+  UNDER
+}
+
+enum ResultOutcome {
+  WIN
+  LOSE
+  PUSH
+}
+
+model Team {
+  id        Int     @id @default(autoincrement())
+  name      String
+  league    String
+  homeGames Game[]  @relation("HomeTeam")
+  awayGames Game[]  @relation("AwayTeam")
+}
+
+model Game {
+  id           Int      @id @default(autoincrement())
+  league       String
+  date         DateTime
+  finalized    Boolean  @default(false)
+  homeTeamId   Int
+  awayTeamId   Int
+  homeTeam     Team     @relation("HomeTeam", fields: [homeTeamId], references: [id])
+  awayTeam     Team     @relation("AwayTeam", fields: [awayTeamId], references: [id])
+  markets      Market[]
+}
+
+model Market {
+  id          Int              @id @default(autoincrement())
+  gameId      Int
+  type        MarketType
+  selection   MarketSelection
+  line        Float?
+  game        Game             @relation(fields: [gameId], references: [id])
+  odds        Odds[]
+  modelProbs  ModelProb[]
+  picks       Pick[]
+  result      Result?
+}
+
+model Odds {
+  id          Int      @id @default(autoincrement())
+  marketId    Int
+  bookmaker   String
+  oddsDecimal Float
+  createdAt   DateTime @default(now())
+  market      Market   @relation(fields: [marketId], references: [id])
+}
+
+model ModelProb {
+  id        Int      @id @default(autoincrement())
+  marketId  Int
+  pModel    Float
+  modelTag  String
+  createdAt DateTime @default(now())
+  market    Market   @relation(fields: [marketId], references: [id])
+}
+
+model Pick {
+  id          Int           @id @default(autoincrement())
+  marketId    Int
+  selection   PickSelection
+  stakeUnits  Float
+  kellyFactor Float
+  createdAt   DateTime @default(now())
+  market      Market        @relation(fields: [marketId], references: [id])
+}
+
+model Result {
+  id        Int            @id @default(autoincrement())
+  marketId  Int            @unique
+  outcome   ResultOutcome
+  settledAt DateTime @default(now())
+  market    Market         @relation(fields: [marketId], references: [id])
+}
+
+model MetricDaily {
+  id   Int    @id @default(autoincrement())
+  date DateTime @unique
+  kpi  Json
+}
+
+model UploadLog {
+  id        Int      @id @default(autoincrement())
+  filename  String
+  createdAt DateTime @default(now())
+  meta      Json
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,242 @@
+import {
+  MarketSelection,
+  MarketType,
+  PickSelection,
+  PrismaClient,
+  ResultOutcome
+} from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const leagues = [
+  {
+    league: 'NBA',
+    teams: ['台北戰神', '高雄火焰', '新竹巨浪', '台中雷霆']
+  },
+  {
+    league: 'MLB',
+    teams: ['台北猛虎', '台中飛魚', '高雄犀牛', '花蓮鯨']
+  }
+];
+
+const homeOddsList = [1.72, 1.68, 1.82, 1.95];
+const awayOddsList = [2.15, 2.25, 2.05, 1.92];
+const overOddsList = [1.91, 1.87, 1.93, 1.88];
+const underOddsList = [1.95, 1.92, 1.9, 1.96];
+const homeModelList = [0.59, 0.66, 0.62, 0.69];
+const overModelList = [0.56, 0.64, 0.6, 0.67];
+
+function calculateEv(pModel: number, oddsDecimal: number) {
+  return pModel * (oddsDecimal - 1) - (1 - pModel);
+}
+
+function calculateKelly(pModel: number, oddsDecimal: number) {
+  const b = oddsDecimal - 1;
+  if (b <= 0) return 0;
+  const fraction = (b * pModel - (1 - pModel)) / b;
+  return fraction > 0 ? fraction : 0;
+}
+
+async function main() {
+  await prisma.metricDaily.deleteMany();
+  await prisma.result.deleteMany();
+  await prisma.pick.deleteMany();
+  await prisma.modelProb.deleteMany();
+  await prisma.odds.deleteMany();
+  await prisma.market.deleteMany();
+  await prisma.game.deleteMany();
+  await prisma.team.deleteMany();
+  await prisma.uploadLog.deleteMany();
+
+  const teamMap = new Map<string, number[]>();
+
+  for (const { league, teams } of leagues) {
+    const ids: number[] = [];
+    for (const name of teams) {
+      const team = await prisma.team.create({
+        data: { name, league }
+      });
+      ids.push(team.id);
+    }
+    teamMap.set(league, ids);
+  }
+
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  const start = new Date(today);
+  start.setUTCDate(start.getUTCDate() - 29);
+
+  for (let dayOffset = 0; dayOffset < 30; dayOffset += 1) {
+    const gameDate = new Date(start);
+    gameDate.setUTCDate(start.getUTCDate() + dayOffset);
+    gameDate.setUTCHours(12, 0, 0, 0);
+
+    for (const [leagueIndex, { league }] of leagues.entries()) {
+      const teamIds = teamMap.get(league)!;
+      const homeTeamId = teamIds[(dayOffset + leagueIndex) % teamIds.length];
+      const awayTeamId = teamIds[(dayOffset + leagueIndex + 1) % teamIds.length];
+      const variant = (dayOffset + leagueIndex) % 4;
+
+      const game = await prisma.game.create({
+        data: {
+          league,
+          date: gameDate,
+          finalized: true,
+          homeTeamId,
+          awayTeamId
+        }
+      });
+
+      const homeOdds = homeOddsList[variant];
+      const awayOdds = awayOddsList[variant];
+      const overOdds = overOddsList[variant];
+      const underOdds = underOddsList[variant];
+      const homeModel = homeModelList[variant];
+      const awayModel = Math.max(0.25, 1 - homeModel - 0.05);
+      const overModel = overModelList[variant];
+      const underModel = Math.max(0.25, 1 - overModel - 0.05);
+      const totalLine = league === 'NBA' ? 216 + variant * 4 : 7.5 + variant * 0.5;
+
+      const homeMarket = await prisma.market.create({
+        data: {
+          gameId: game.id,
+          type: MarketType.ML,
+          selection: MarketSelection.HOME
+        }
+      });
+      const awayMarket = await prisma.market.create({
+        data: {
+          gameId: game.id,
+          type: MarketType.ML,
+          selection: MarketSelection.AWAY
+        }
+      });
+      const overMarket = await prisma.market.create({
+        data: {
+          gameId: game.id,
+          type: MarketType.TOTAL,
+          selection: MarketSelection.OVER,
+          line: totalLine
+        }
+      });
+      const underMarket = await prisma.market.create({
+        data: {
+          gameId: game.id,
+          type: MarketType.TOTAL,
+          selection: MarketSelection.UNDER,
+          line: totalLine
+        }
+      });
+
+      const oddsPayload = [
+        { marketId: homeMarket.id, oddsDecimal: homeOdds },
+        { marketId: awayMarket.id, oddsDecimal: awayOdds },
+        { marketId: overMarket.id, oddsDecimal: overOdds },
+        { marketId: underMarket.id, oddsDecimal: underOdds }
+      ];
+
+      for (const payload of oddsPayload) {
+        await prisma.odds.create({
+          data: {
+            marketId: payload.marketId,
+            bookmaker: 'DemoBook',
+            oddsDecimal: payload.oddsDecimal,
+            createdAt: gameDate
+          }
+        });
+      }
+
+      const modelPayload = [
+        { marketId: homeMarket.id, pModel: homeModel },
+        { marketId: awayMarket.id, pModel: awayModel },
+        { marketId: overMarket.id, pModel: overModel },
+        { marketId: underMarket.id, pModel: underModel }
+      ];
+
+      for (const payload of modelPayload) {
+        await prisma.modelProb.create({
+          data: {
+            marketId: payload.marketId,
+            pModel: payload.pModel,
+            modelTag: 'baseline_v1',
+            createdAt: gameDate
+          }
+        });
+      }
+
+      const homeWin = (dayOffset + leagueIndex) % 3 !== 0;
+      const totalOver = (dayOffset + variant) % 2 === 0;
+
+      await prisma.result.create({
+        data: {
+          marketId: homeMarket.id,
+          outcome: homeWin ? ResultOutcome.WIN : ResultOutcome.LOSE,
+          settledAt: new Date(gameDate.getTime() + 4 * 60 * 60 * 1000)
+        }
+      });
+      await prisma.result.create({
+        data: {
+          marketId: awayMarket.id,
+          outcome: homeWin ? ResultOutcome.LOSE : ResultOutcome.WIN,
+          settledAt: new Date(gameDate.getTime() + 4 * 60 * 60 * 1000)
+        }
+      });
+      await prisma.result.create({
+        data: {
+          marketId: overMarket.id,
+          outcome: totalOver ? ResultOutcome.WIN : ResultOutcome.LOSE,
+          settledAt: new Date(gameDate.getTime() + 4 * 60 * 60 * 1000)
+        }
+      });
+      await prisma.result.create({
+        data: {
+          marketId: underMarket.id,
+          outcome: totalOver ? ResultOutcome.LOSE : ResultOutcome.WIN,
+          settledAt: new Date(gameDate.getTime() + 4 * 60 * 60 * 1000)
+        }
+      });
+
+      const picks = [
+        {
+          marketId: homeMarket.id,
+          selection: PickSelection.HOME,
+          odds: homeOdds,
+          pModel: homeModel
+        },
+        {
+          marketId: overMarket.id,
+          selection: PickSelection.OVER,
+          odds: overOdds,
+          pModel: overModel
+        }
+      ];
+
+      for (const pick of picks) {
+        const ev = calculateEv(pick.pModel, pick.odds);
+        const kelly = calculateKelly(pick.pModel, pick.odds);
+        if (ev > 0 && kelly > 0.01) {
+          await prisma.pick.create({
+            data: {
+              marketId: pick.marketId,
+              selection: pick.selection,
+              stakeUnits: Number((Math.max(0.25, kelly) * 1.5).toFixed(2)),
+              kellyFactor: 0.5,
+              createdAt: gameDate
+            }
+          });
+        }
+      }
+    }
+  }
+
+  console.log('資料庫已建立 30 天示範資料');
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/backtest.ts
+++ b/scripts/backtest.ts
@@ -1,0 +1,144 @@
+import { MarketType } from '@prisma/client';
+import { subDays } from 'date-fns';
+import { prisma } from '@/lib/prisma';
+import {
+  calculateEv,
+  calculatePerformanceMetrics,
+  calculateProfit,
+  fillMissingDates,
+  toDateKey
+} from '@/lib/analytics';
+
+async function main() {
+  const minProbability = Number(process.env.MIN_PROB ?? '0.6');
+  const minEv = Number(process.env.MIN_EV ?? '0');
+  const stakeUnits = Number(process.env.STAKE ?? '1');
+  const maxConcurrent = Number(process.env.MAX_CONCURRENT ?? '3');
+  const end = process.env.END_DATE ? new Date(`${process.env.END_DATE}T23:59:59+08:00`) : new Date();
+  const start = process.env.START_DATE
+    ? new Date(`${process.env.START_DATE}T00:00:00+08:00`)
+    : subDays(end, 30);
+  const leagueFilter = process.env.LEAGUES
+    ? process.env.LEAGUES.split(',').map((item) => item.trim()).filter(Boolean)
+    : undefined;
+  const marketTypes = process.env.MARKETS
+    ? process.env.MARKETS.split(',')
+        .map((item) => item.trim().toUpperCase())
+        .filter((item): item is keyof typeof MarketType => item in MarketType)
+        .map((item) => MarketType[item])
+    : [MarketType.ML, MarketType.SPREAD, MarketType.TOTAL];
+
+  const markets = await prisma.market.findMany({
+    where: {
+      type: { in: marketTypes },
+      game: {
+        league: leagueFilter ? { in: leagueFilter } : undefined,
+        date: {
+          gte: start,
+          lte: end
+        }
+      }
+    },
+    include: {
+      game: {
+        include: {
+          homeTeam: true,
+          awayTeam: true
+        }
+      },
+      odds: {
+        orderBy: { createdAt: 'desc' },
+        take: 1
+      },
+      modelProbs: {
+        orderBy: { createdAt: 'desc' },
+        take: 1
+      },
+      result: true
+    }
+  });
+
+  const grouped = new Map<string, typeof markets>();
+  for (const market of markets) {
+    const key = toDateKey(market.game.date);
+    const list = grouped.get(key);
+    if (list) {
+      list.push(market);
+    } else {
+      grouped.set(key, [market]);
+    }
+  }
+
+  const selected: {
+    date: string;
+    league: string;
+    matchup: string;
+    marketType: MarketType;
+    selection: string;
+    oddsDecimal: number;
+    pModel: number;
+    ev: number;
+    result: string;
+    profit: number;
+  }[] = [];
+
+  for (const [date, list] of grouped.entries()) {
+    const eligible = list
+      .map((market) => {
+        const odds = market.odds[0];
+        const model = market.modelProbs[0];
+        if (!odds || !model) return null;
+        const ev = calculateEv(model.pModel, odds.oddsDecimal);
+        if (model.pModel < minProbability || ev < minEv) return null;
+        return { market, ev, odds, model };
+      })
+      .filter((item): item is { market: (typeof markets)[number]; ev: number; odds: any; model: any } => !!item)
+      .sort((a, b) => b.ev - a.ev)
+      .slice(0, maxConcurrent);
+
+    for (const pick of eligible) {
+      const profit = calculateProfit(pick.market.result?.outcome ?? 'PUSH', pick.odds.oddsDecimal, stakeUnits);
+      selected.push({
+        date,
+        league: pick.market.game.league,
+        matchup: `${pick.market.game.awayTeam.name} @ ${pick.market.game.homeTeam.name}`,
+        marketType: pick.market.type,
+        selection: pick.market.selection,
+        oddsDecimal: pick.odds.oddsDecimal,
+        pModel: pick.model.pModel,
+        ev: pick.ev,
+        result: pick.market.result?.outcome ?? 'PUSH',
+        profit
+      });
+    }
+  }
+
+  const metrics = calculatePerformanceMetrics(
+    selected
+      .sort((a, b) => a.date.localeCompare(b.date))
+      .map((pick) => ({
+        stakeUnits,
+        oddsDecimal: pick.oddsDecimal,
+        outcome: pick.result as 'WIN' | 'LOSE' | 'PUSH',
+        date: new Date(`${pick.date}T12:00:00+08:00`)
+      }))
+  );
+  const equity = fillMissingDates(metrics.equityCurve);
+
+  console.log('===== 回測結果 =====');
+  console.log('樣本數', metrics.sampleSize);
+  console.log('命中率', formatPercent(metrics.hitRate));
+  console.log('ROI', formatPercent(metrics.roi));
+  console.log('累積 Units', metrics.units.toFixed(2));
+  console.log('最大回撤', metrics.maxDrawdown.toFixed(2));
+  console.log('每日損益 (前 5 日)', equity.slice(0, 5));
+}
+
+function formatPercent(value: number) {
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/importCsv.ts
+++ b/scripts/importCsv.ts
@@ -1,0 +1,23 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { parseCsv } from '@/lib/csv';
+import { importDataset } from '@/lib/upload';
+
+async function main() {
+  const dataDir = path.resolve(process.cwd(), 'data');
+  const gamesCsv = fs.readFileSync(path.join(dataDir, 'games.csv'), 'utf-8');
+  const oddsCsv = fs.readFileSync(path.join(dataDir, 'odds.csv'), 'utf-8');
+  const modelCsv = fs.readFileSync(path.join(dataDir, 'model.csv'), 'utf-8');
+
+  const games = parseCsv(gamesCsv).rows as any;
+  const odds = parseCsv(oddsCsv).rows as any;
+  const models = parseCsv(modelCsv).rows as any;
+
+  const summary = await importDataset({ games, odds, models });
+  console.log('匯入完成', summary);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+    './lib/**/*.{js,ts,jsx,tsx,mdx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calculateEv,
+  calculateImpliedProbability,
+  calculateKellyFraction,
+  calculatePerformanceMetrics,
+  calculateWilsonInterval,
+  fillMissingDates,
+  getKellyStakeTiers,
+  removeVig
+} from '@/lib/analytics';
+
+const makeDate = (date: string) => new Date(`${date}T12:00:00+08:00`);
+
+describe('analytics helpers', () => {
+  it('calculates implied probability', () => {
+    const implied = calculateImpliedProbability(1.8);
+    expect(implied).toBeCloseTo(0.5555, 3);
+  });
+
+  it('removes vig from odds', () => {
+    const normalized = removeVig([1.8, 2.0]);
+    const sum = normalized.reduce((acc, val) => acc + val, 0);
+    expect(sum).toBeCloseTo(1, 5);
+    expect(normalized[0]).toBeGreaterThan(0.5);
+  });
+
+  it('calculates expectation value', () => {
+    const ev = calculateEv(0.6, 1.9);
+    expect(ev).toBeCloseTo(0.14, 2);
+  });
+
+  it('calculates Kelly fraction', () => {
+    const fraction = calculateKellyFraction(0.62, 1.8);
+    expect(fraction).toBeGreaterThan(0);
+    expect(fraction).toBeLessThan(1);
+  });
+
+  it('generates Kelly tiers', () => {
+    const tiers = getKellyStakeTiers(1, 0.2);
+    expect(tiers['25%']).toBeCloseTo(0.05, 2);
+    expect(tiers['50%']).toBeCloseTo(0.1, 2);
+    expect(tiers['100%']).toBeCloseTo(0.2, 2);
+  });
+
+  it('computes Wilson interval', () => {
+    const interval = calculateWilsonInterval(60, 100);
+    expect(interval.low).toBeLessThan(interval.high);
+    expect(interval.low).toBeGreaterThan(0.5);
+  });
+
+  it('calculates performance metrics with drawdown', () => {
+    const picks = [
+      { stakeUnits: 1, oddsDecimal: 1.9, outcome: 'WIN' as const, date: makeDate('2024-04-01') },
+      { stakeUnits: 1, oddsDecimal: 1.9, outcome: 'LOSE' as const, date: makeDate('2024-04-02') },
+      { stakeUnits: 1, oddsDecimal: 2.1, outcome: 'WIN' as const, date: makeDate('2024-04-03') }
+    ];
+    const metrics = calculatePerformanceMetrics(picks);
+    expect(metrics.hitRate).toBeCloseTo(2 / 3, 3);
+    expect(metrics.units).toBeGreaterThan(0);
+    expect(metrics.maxDrawdown).toBeGreaterThanOrEqual(1);
+    expect(metrics.equityCurve).toHaveLength(3);
+  });
+
+  it('fills missing dates with carry over equity', () => {
+    const curve = [
+      { date: '2024-04-01', delta: 1, equity: 1 },
+      { date: '2024-04-03', delta: -0.5, equity: 0.5 }
+    ];
+    const filled = fillMissingDates(curve);
+    expect(filled).toHaveLength(3);
+    expect(filled[1].date).toBe('2024-04-02');
+    expect(filled[1].equity).toBeCloseTo(1, 2);
+  });
+});

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test('首頁顯示 KPI 與走勢圖', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'networkidle' });
+  await expect(page.getByText('體育賽事 AI 分析儀表板')).toBeVisible();
+  await expect(page.getByText('近 20 天命中率')).toBeVisible();
+  await expect(page.getByText('最新正期望值投注')).toBeVisible();
+});
+
+test('報告頁切換模式與匯出按鈕存在', async ({ page }) => {
+  await page.goto('/reports', { waitUntil: 'networkidle' });
+  await expect(page.getByRole('button', { name: '高勝率（p ≥ 0.60）' })).toBeVisible();
+  await expect(page.getByRole('button', { name: '正期望值（EV > 0）' })).toBeVisible();
+  await expect(page.getByPlaceholder('搜尋聯盟 / 對賽 / 模型標籤')).toBeVisible();
+  await page.getByRole('button', { name: '匯出 CSV' }).isEnabled();
+});
+
+test('賽程頁可套用篩選器', async ({ page }) => {
+  await page.goto('/games', { waitUntil: 'networkidle' });
+  await expect(page.getByText('賽程 / 歷史結果')).toBeVisible();
+  await expect(page.getByRole('button', { name: '套用篩選' })).toBeVisible();
+});
+
+test('上傳頁顯示欄位提示', async ({ page }) => {
+  await page.goto('/upload', { waitUntil: 'networkidle' });
+  await expect(page.getByText('資料上傳 / 更新')).toBeVisible();
+  await expect(page.getByText('games.csv：date, league, home, away, finalized, result_side, closing_total')).toBeVisible();
+});
+
+test('回測頁載入並顯示表單', async ({ page }) => {
+  await page.goto('/backtest', { waitUntil: 'networkidle' });
+  await expect(page.getByText('策略回測')).toBeVisible();
+  await expect(page.getByRole('button', { name: '開始回測' })).toBeVisible();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["vitest/globals", "@types/node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts", "**/*.d.ts"],
+  "exclude": ["node_modules"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts']
+  }
+});


### PR DESCRIPTION
## Summary
- implement Next.js 14 app with KPI dashboard, high win/EV reports, games browser, upload flow, and strategy backtest
- add Prisma schema, seed generator, reusable analytics utilities, CSV samples, and helper scripts
- configure API routes, Tailwind styling, and author Vitest plus Playwright test suites

## Testing
- npm install *(fails: 403 Forbidden when downloading @playwright/test in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d18f2b3890832d9a9fe0f26a88dd6f